### PR TITLE
[Fp 112 feat/event] : Event 도메인 3차 스프린트 작업

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,8 +8,6 @@
         <processorPath useClasspath="false">
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.36/5a30490a6e14977d97d9c73c924c1f1b5311ea95/lombok-1.18.36.jar" />
         </processorPath>
-        <module name="fix-ticketing.event-service.main" />
-        <module name="fix-ticketing.stadium-service.main" />
         <module name="fix-ticketing.gateway-service.main" />
         <module name="fix-ticketing.server.main" />
         <module name="fix-ticketing.alarm-service.main" />
@@ -29,11 +27,20 @@
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/com.mysema.commons/mysema-commons-lang/0.2.4/d09c8489d54251a6c22fbce804bdd4a070557317/mysema-commons-lang-0.2.4.jar" />
           <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.eclipse.jdt/ecj/3.26.0/4837be609a3368a0f7e7cf0dc1bdbc7fe94993de/ecj-3.26.0.jar" />
         </processorPath>
+        <module name="fix-ticketing.event-service.main" />
         <module name="fix-ticketing.game-service.main" />
         <module name="fix-ticketing.order-service.main" />
-        <module name="fix-ticketing.event-service.main" />
         <module name="fix-ticketing.user-service.main" />
         <module name="fix-ticketing.common-service.main" />
+      </profile>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.36/5a30490a6e14977d97d9c73c924c1f1b5311ea95/lombok-1.18.36.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.persistence/jakarta.persistence-api/3.1.0/66901fa1c373c6aff65c13791cc11da72060a8d6/jakarta.persistence-api-3.1.0.jar" />
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/jakarta.annotation/jakarta.annotation-api/2.1.1/48b9bda22b091b1f48b13af03fe36db3be6e1ae3/jakarta.annotation-api-2.1.1.jar" />
+        </processorPath>
+        <module name="fix-ticketing.stadium-service.main" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17">

--- a/event-service/src/main/java/com/fix/event_service/EventServiceApplication.java
+++ b/event-service/src/main/java/com/fix/event_service/EventServiceApplication.java
@@ -2,8 +2,10 @@ package com.fix.event_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
+@EnableFeignClients
 public class EventServiceApplication {
 
 	public static void main(String[] args) {

--- a/event-service/src/main/java/com/fix/event_service/application/aop/ValidateUser.java
+++ b/event-service/src/main/java/com/fix/event_service/application/aop/ValidateUser.java
@@ -1,0 +1,10 @@
+package com.fix.event_service.application.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidateUser {
+	String[] roles() default {};
+}

--- a/event-service/src/main/java/com/fix/event_service/application/aop/ValidateUserAspect.java
+++ b/event-service/src/main/java/com/fix/event_service/application/aop/ValidateUserAspect.java
@@ -1,0 +1,45 @@
+package com.fix.event_service.application.aop;
+
+import com.fix.event_service.application.exception.EventException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@Slf4j
+public class ValidateUserAspect {
+
+	@Around("@annotation(validateUser)")
+	public Object validateUserHeader(ProceedingJoinPoint joinPoint, ValidateUser validateUser) throws Throwable {
+		ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+		HttpServletRequest request = attrs.getRequest();
+
+		String userId = request.getHeader("x-user-id");
+		String userRole = request.getHeader("x-user-role");
+
+		if (userId == null || userRole == null) {
+			log.warn("Missing headers - userId: {}, userRole: {}", userId, userRole);
+			throw new EventException(EventException.EventErrorType.EVENT_ROLE_UNAUTHORIZED);
+		}
+
+		// 역할 확인
+		String[] allowedRoles = validateUser.roles();
+		boolean authorized = Arrays.stream(allowedRoles)
+			.anyMatch(role -> role.equalsIgnoreCase(userRole));
+
+		if (!authorized) {
+			log.warn("Access denied. userId: {}, role: {}, allowedRoles: {}", userId, userRole, Arrays.toString(allowedRoles));
+			throw new EventException(EventException.EventErrorType.EVENT_ROLE_UNAUTHORIZED);
+		}
+
+		return joinPoint.proceed();
+	}
+}

--- a/event-service/src/main/java/com/fix/event_service/application/dtos/request/EventCreateRequestDto.java
+++ b/event-service/src/main/java/com/fix/event_service/application/dtos/request/EventCreateRequestDto.java
@@ -15,5 +15,6 @@ public class EventCreateRequestDto {
     private LocalDateTime eventStartAt;
     private LocalDateTime eventEndAt;
     private Integer maxWinners;
+    private Integer requiredPoints;
     private RewardRequestDto reward;
 }

--- a/event-service/src/main/java/com/fix/event_service/application/dtos/request/EventUpdateRequestDto.java
+++ b/event-service/src/main/java/com/fix/event_service/application/dtos/request/EventUpdateRequestDto.java
@@ -15,5 +15,6 @@ public class EventUpdateRequestDto {
     private LocalDateTime eventStartAt;
     private LocalDateTime eventEndAt;
     private Integer maxWinners;
+    private Integer requiredPoints;
     private RewardRequestDto reward;
 }

--- a/event-service/src/main/java/com/fix/event_service/application/dtos/response/EventDetailResponseDto.java
+++ b/event-service/src/main/java/com/fix/event_service/application/dtos/response/EventDetailResponseDto.java
@@ -16,6 +16,7 @@ public class EventDetailResponseDto {
     private String eventStartAt;
     private String eventEndAt;
     private Integer maxWinners;
+    private Integer requiredPoints;
     private EventStatus status;
     private RewardResponseDto reward;
 
@@ -26,6 +27,7 @@ public class EventDetailResponseDto {
         this.eventStartAt = event.getEventPeriod().getEventStartAt().toString();
         this.eventEndAt = event.getEventPeriod().getEventEndAt().toString();
         this.maxWinners = event.getMaxWinners();
+        this.requiredPoints = event.getRequiredPoints();
         this.status = event.getStatus();
         this.reward = new RewardResponseDto(event.getReward());
     }

--- a/event-service/src/main/java/com/fix/event_service/application/dtos/response/EventResponseDto.java
+++ b/event-service/src/main/java/com/fix/event_service/application/dtos/response/EventResponseDto.java
@@ -16,6 +16,7 @@ public class EventResponseDto {
     private String eventStartAt;
     private String eventEndAt;
     private Integer maxWinners;
+    private Integer requiredPoints;
     private EventStatus status;
 
     public EventResponseDto(Event event) {
@@ -25,6 +26,7 @@ public class EventResponseDto {
         this.eventStartAt = event.getEventPeriod().getEventStartAt().toString();
         this.eventEndAt = event.getEventPeriod().getEventEndAt().toString();
         this.maxWinners = event.getMaxWinners();
+        this.requiredPoints = event.getRequiredPoints();
         this.status = event.getStatus();
     }
 }

--- a/event-service/src/main/java/com/fix/event_service/application/exception/EventException.java
+++ b/event-service/src/main/java/com/fix/event_service/application/exception/EventException.java
@@ -1,0 +1,34 @@
+package com.fix.event_service.application.exception;
+
+import com.fix.common_service.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class EventException extends CustomException {
+
+	public EventException(EventErrorType errorType) {
+		super(errorType.getCode(), errorType.getMessage(), errorType.getStatus());
+	}
+
+	@Getter
+	public enum EventErrorType {
+		EVENT_NOT_FOUND("EVENT_001", HttpStatus.NOT_FOUND, "이벤트를 찾을 수 없습니다."),
+		EVENT_CANNOT_UPDATE("EVENT_002", HttpStatus.BAD_REQUEST, "진행중이거나 종료된 이벤트는 수정할 수 없습니다."),
+		EVENT_CANNOT_DELETE("EVENT_003", HttpStatus.BAD_REQUEST, "응모가 진행중인 이벤트는 삭제할 수 없습니다."),
+		EVENT_NOT_OPEN_FOR_APPLY("EVENT_004", HttpStatus.BAD_REQUEST, "이벤트 응모 기간이 아닙니다."),
+		EVENT_INVALID_PERIOD("EVENT_005", HttpStatus.BAD_REQUEST, "이벤트 시간 범위가 유효하지 않습니다."),
+		REWARD_LACK("EVENT_006", HttpStatus.BAD_REQUEST, "상품 재고가 부족합니다."),
+		EVENT_ROLE_UNAUTHORIZED("EVENT_007", HttpStatus.UNAUTHORIZED, "이벤트 관련 권한이 없습니다.");
+
+		private final String code;
+		private final HttpStatus status;
+		private final String message;
+
+		EventErrorType(String code, HttpStatus status, String message) {
+			this.code = code;
+			this.status = status;
+			this.message = message;
+		}
+	}
+}

--- a/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
+++ b/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.fix.event_service.application.exception;
+
+import com.fix.common_service.dto.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class EventExceptionHandler {
+
+	@ExceptionHandler(exception = {EventException.class})
+	public ResponseEntity<CommonResponse<EventException>> errorResponse(EventException exception) {
+		log.error("[ErrorCode] = {} , [ErrorMessage] = {}", exception.getErrorCode(), exception.getMessage());
+
+		return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
+			exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
+		));
+	}
+}

--- a/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
@@ -3,6 +3,7 @@ package com.fix.event_service.application.service;
 import com.fix.event_service.application.dtos.request.EventCreateRequestDto;
 import com.fix.event_service.application.dtos.request.EventUpdateRequestDto;
 import com.fix.event_service.application.dtos.response.*;
+import com.fix.event_service.application.exception.EventException;
 import com.fix.event_service.domain.model.Event;
 import com.fix.event_service.domain.model.EventEntry;
 import com.fix.event_service.domain.model.EventStatus;
@@ -156,6 +157,6 @@ public class EventApplicationService {
 
     private Event findEventById(UUID eventId) {
         return eventRepository.findById(eventId)
-                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EventException(EventException.EventErrorType.EVENT_NOT_FOUND));
     }
 }

--- a/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
@@ -10,6 +10,7 @@ import com.fix.event_service.domain.model.EventStatus;
 import com.fix.event_service.domain.model.Reward;
 import com.fix.event_service.domain.repository.EventRepository;
 import com.fix.event_service.domain.service.EventDomainService;
+import com.fix.event_service.infrastructure.client.UserClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -28,6 +29,7 @@ public class EventApplicationService {
 
     private final EventRepository eventRepository;
     private final EventDomainService eventDomainService;
+    private final UserClient userClient;
 
     @Transactional
     public EventDetailResponseDto createEvent(EventCreateRequestDto requestDto) {
@@ -58,6 +60,8 @@ public class EventApplicationService {
         Event event = findEventById(eventId);
 
         event.isEventOpenForApplication();
+
+        userClient.deductPoints(userId, event.getRequiredPoints());
 
         EventEntry entry = EventEntry.createEventEntry(event, userId);
 

--- a/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
@@ -31,8 +31,6 @@ public class EventApplicationService {
 
     @Transactional
     public EventDetailResponseDto createEvent(EventCreateRequestDto requestDto) {
-        // TODO : Event의 중복 검사 로직? 필요 없을지도..
-
         Event event = Event.createEvent(
                 requestDto.getEventName(),
                 requestDto.getDescription(),
@@ -55,9 +53,7 @@ public class EventApplicationService {
     }
 
     @Transactional
-    public void applyEvent(UUID eventId) {
-        Long userId = 1L; // TODO : 실제 유저 Id 넣기
-
+    public void applyEvent(UUID eventId, Long userId) {
         Event event = findEventById(eventId);
 
         event.isEventOpenForApplication();
@@ -147,12 +143,12 @@ public class EventApplicationService {
     }
 
     @Transactional
-    public void deleteEvent(UUID eventId) {
+    public void deleteEvent(UUID eventId, Long userId) {
         Event event = findEventById(eventId);
 
         event.checkDeletable();
 
-        event.softDelete(1L); // TODO : 유저 Id 넣기
+        event.softDelete(userId);
     }
 
     private Event findEventById(UUID eventId) {

--- a/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
@@ -36,7 +36,8 @@ public class EventApplicationService {
                 requestDto.getDescription(),
                 requestDto.getEventStartAt(),
                 requestDto.getEventEndAt(),
-                requestDto.getMaxWinners()
+                requestDto.getMaxWinners(),
+                requestDto.getRequiredPoints()
         );
 
         Reward reward = Reward.createReward(
@@ -114,6 +115,7 @@ public class EventApplicationService {
                 requestDto.getEventStartAt(),
                 requestDto.getEventEndAt(),
                 requestDto.getMaxWinners(),
+                requestDto.getRequiredPoints(),
                 newReward
         );
 

--- a/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
+++ b/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
@@ -25,6 +25,7 @@ public class Event extends Basic {
     private String eventName;
     private String description;
     private Integer maxWinners;
+    private Integer requiredPoints;
 
     @Embedded
     private EventPeriod eventPeriod;
@@ -39,31 +40,36 @@ public class Event extends Basic {
     private List<EventEntry> entries = new ArrayList<>();
 
     @Builder
-    public Event(String eventName, String description, LocalDateTime eventStartAt, LocalDateTime eventEndAt, Integer maxWinners) {
+    public Event(String eventName, String description, LocalDateTime eventStartAt,
+                 LocalDateTime eventEndAt, Integer maxWinners, Integer requiredPoints) {
         this.eventId = UUID.randomUUID();
         this.eventName = eventName;
         this.description = description;
         this.eventPeriod = new EventPeriod(eventStartAt, eventEndAt);
         this.maxWinners = maxWinners;
+        this.requiredPoints = requiredPoints;
         this.status = EventStatus.PLANNED;
     }
 
-    public static Event createEvent(String eventName, String description, LocalDateTime eventStartAt, LocalDateTime eventEndAt, Integer maxWinners) {
+    public static Event createEvent(String eventName, String description, LocalDateTime eventStartAt,
+                                    LocalDateTime eventEndAt, Integer maxWinners, Integer requiredPoints) {
         return Event.builder()
                 .eventName(eventName)
                 .description(description)
                 .eventStartAt(eventStartAt)
                 .eventEndAt(eventEndAt)
                 .maxWinners(maxWinners)
+                .requiredPoints(requiredPoints)
                 .build();
     }
 
-    public void updateEvent(
-        String eventName, String description, LocalDateTime eventStartAt, LocalDateTime eventEndAt, Integer maxWinners, Reward reward) {
+    public void updateEvent(String eventName, String description, LocalDateTime eventStartAt,
+                            LocalDateTime eventEndAt, Integer maxWinners, Integer requiredPoints, Reward reward) {
         this.eventName = eventName;
         this.description = description;
         this.eventPeriod = new EventPeriod(eventStartAt, eventEndAt);
         this.maxWinners = maxWinners;
+        this.requiredPoints = requiredPoints;
         this.reward = reward;
     }
 

--- a/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
+++ b/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
@@ -1,6 +1,7 @@
 package com.fix.event_service.domain.model;
 
 import com.fix.common_service.entity.Basic;
+import com.fix.event_service.application.exception.EventException;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -68,13 +69,13 @@ public class Event extends Basic {
 
     public void checkUpdatable() {
         if (this.status != EventStatus.PLANNED) {
-            throw new IllegalStateException("진행중이거나 종료된 이벤트는 수정할 수 없습니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_CANNOT_UPDATE);
         }
     }
 
     public void checkDeletable() {
         if (this.status == EventStatus.ONGOING) {
-            throw new IllegalStateException("응모가 진행중인 이벤트는 삭제할 수 없습니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_CANNOT_DELETE);
         }
     }
 
@@ -103,7 +104,7 @@ public class Event extends Basic {
         boolean isBeforeEnd = now.isBefore(eventPeriod.getEventEndAt());
 
         if (!isOngoing || !isAfterStart || !isBeforeEnd) {
-            throw new IllegalStateException("이벤트 응모 기간이 아닙니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_NOT_OPEN_FOR_APPLY);
         }
     }
 

--- a/event-service/src/main/java/com/fix/event_service/domain/model/EventPeriod.java
+++ b/event-service/src/main/java/com/fix/event_service/domain/model/EventPeriod.java
@@ -1,5 +1,6 @@
 package com.fix.event_service.domain.model;
 
+import com.fix.event_service.application.exception.EventException;
 import jakarta.persistence.Embeddable;
 import lombok.Getter;
 
@@ -19,13 +20,13 @@ public class EventPeriod {
     public EventPeriod(LocalDateTime eventStartAt, LocalDateTime eventEndAt) {
         LocalDateTime now = LocalDateTime.now();
         if (eventStartAt == null || eventEndAt == null) {
-            throw new IllegalArgumentException("이벤트 시작 및 종료 시간은 null일 수 없습니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_INVALID_PERIOD);
         }
         if (eventStartAt.isAfter(eventEndAt)) {
-            throw new IllegalArgumentException("이벤트 시작 시간은 종료 시간보다 늦을 수 없습니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_INVALID_PERIOD);
         }
         if (eventStartAt.isBefore(now)) {
-            throw new IllegalArgumentException("이벤트 시작 시간은 현재 시간보다 과거일 수 없습니다.");
+            throw new EventException(EventException.EventErrorType.EVENT_INVALID_PERIOD);
         }
         this.eventStartAt = eventStartAt;
         this.eventEndAt = eventEndAt;

--- a/event-service/src/main/java/com/fix/event_service/domain/model/Reward.java
+++ b/event-service/src/main/java/com/fix/event_service/domain/model/Reward.java
@@ -1,6 +1,7 @@
 package com.fix.event_service.domain.model;
 
 import com.fix.common_service.entity.Basic;
+import com.fix.event_service.application.exception.EventException;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -47,7 +48,7 @@ public class Reward extends Basic {
 
     public void decreaseQuantity(int amount) {
         if (this.quantity < amount) {
-            throw new IllegalStateException("상품 재고가 부족합니다");
+            throw new EventException(EventException.EventErrorType.REWARD_LACK);
         }
         this.quantity -= amount;
     }

--- a/event-service/src/main/java/com/fix/event_service/infrastructure/client/UserClient.java
+++ b/event-service/src/main/java/com/fix/event_service/infrastructure/client/UserClient.java
@@ -1,0 +1,13 @@
+package com.fix.event_service.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+    @PostMapping("/api/v1/users/feign/deduct-points/{userId}")
+    void deductPoints(@PathVariable("userId") Long userId, @RequestParam("points") Integer requiredPoints);
+}

--- a/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.fix.event_service.presentation.controller;
 
 import com.fix.common_service.dto.CommonResponse;
+import com.fix.event_service.application.aop.ValidateUser;
 import com.fix.event_service.application.dtos.request.EventCreateRequestDto;
 import com.fix.event_service.application.dtos.request.EventUpdateRequestDto;
 import com.fix.event_service.application.dtos.response.*;
@@ -20,6 +21,7 @@ public class EventController {
     private final EventApplicationService eventApplicationService;
 
     // ✅ 이벤트 생성 API
+    @ValidateUser(roles = {"MASTER", "MANAGER"})
     @PostMapping("")
     public ResponseEntity<CommonResponse<EventDetailResponseDto>> createEvent(@RequestBody EventCreateRequestDto requestDto) {
         EventDetailResponseDto responseDto = eventApplicationService.createEvent(requestDto);
@@ -28,8 +30,9 @@ public class EventController {
 
     // ✅ 이벤트 응모 API
     @PostMapping("/{eventId}")
-    public ResponseEntity<CommonResponse<Void>> applyEvent(@PathVariable("eventId") UUID eventId) {
-        eventApplicationService.applyEvent(eventId);
+    public ResponseEntity<CommonResponse<Void>> applyEvent(
+        @PathVariable("eventId") UUID eventId, @RequestHeader("x-user-id") Long userId) {
+        eventApplicationService.applyEvent(eventId, userId);
         return ResponseEntity.ok(CommonResponse.success(null, "이벤트 응모 성공"));
     }
 
@@ -50,6 +53,7 @@ public class EventController {
     }
 
     // ✅ 특정 이벤트 응모 기록(목록) 조회 API
+    @ValidateUser(roles = {"MASTER", "MANAGER"})
     @GetMapping("/{eventId}/entries")
     public ResponseEntity<CommonResponse<PageResponseDto<EventEntryResponseDto>>> getEventEntries(
             @PathVariable("eventId") UUID eventId,
@@ -71,6 +75,7 @@ public class EventController {
     }
 
     // ✅ 이벤트 정보 수정 API
+    @ValidateUser(roles = {"MASTER", "MANAGER"})
     @PutMapping("/{eventId}")
     public ResponseEntity<CommonResponse<EventDetailResponseDto>> updateEvent(
             @PathVariable("eventId") UUID eventId,
@@ -80,6 +85,7 @@ public class EventController {
     }
 
     // ✅ 당첨자 선정 API
+    @ValidateUser(roles = {"MASTER", "MANAGER"})
     @PatchMapping("/{eventId}/announce-winners")
     public ResponseEntity<CommonResponse<WinnerListResponseDto>> announceWinners(@PathVariable("eventId") UUID eventId) {
         WinnerListResponseDto responseDto = eventApplicationService.announceWinners(eventId);
@@ -87,9 +93,11 @@ public class EventController {
     }
 
     // ✅ 이벤트 논리적 삭제 API
+    @ValidateUser(roles = {"MASTER", "MANAGER"})
     @DeleteMapping("/{eventId}")
-    public ResponseEntity<CommonResponse<Void>> deleteEvent(@PathVariable("eventId") UUID eventId) {
-        eventApplicationService.deleteEvent(eventId);
+    public ResponseEntity<CommonResponse<Void>> deleteEvent(
+        @PathVariable("eventId") UUID eventId, @RequestHeader("x-user-id") Long userId) {
+        eventApplicationService.deleteEvent(eventId, userId);
         return ResponseEntity.ok(CommonResponse.success(null, "이벤트 삭제 성공"));
     }
 }

--- a/user-service/src/main/java/com/fix/user_service/application/dtos/response/UserDetailResponseDto.java
+++ b/user-service/src/main/java/com/fix/user_service/application/dtos/response/UserDetailResponseDto.java
@@ -16,6 +16,7 @@ public class UserDetailResponseDto {
     private final String nickname;
     private final String email;
     private final String roleName;
+    private final Integer point;
 
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private final LocalDateTime createdAt;
@@ -30,6 +31,7 @@ public class UserDetailResponseDto {
             .nickname(user.getNickname())
             .email(user.getEmail())
             .roleName(user.getRoleName().name())
+            .point(user.getPoint())
             .createdAt(user.getCreatedAt())
             .updatedAt(user.getUpdatedAt())
             .build();

--- a/user-service/src/main/java/com/fix/user_service/application/exception/UserException.java
+++ b/user-service/src/main/java/com/fix/user_service/application/exception/UserException.java
@@ -43,7 +43,8 @@ public class UserException extends CustomException {
         AUTHENTICATION_FAILED("USER_008", HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
         TOKEN_EXPIRED("USER_009", HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
         USER_SERVICE_UNAVAILABLE("USER_503", HttpStatus.SERVICE_UNAVAILABLE, "User 서비스에 접근할 수 없습니다."),
-        INVALID_UUID_FORMAT("USER_010", HttpStatus.BAD_REQUEST, "잘못된 UUID 형식입니다.");
+        INVALID_UUID_FORMAT("USER_010", HttpStatus.BAD_REQUEST, "잘못된 UUID 형식입니다."),
+        NOT_ENOUGH_POINTS("USER_011", HttpStatus.BAD_REQUEST, "포인트가 부족합니다.");
 
         private final String code;
         private final HttpStatus status;

--- a/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
+++ b/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
@@ -88,6 +88,14 @@ public class UserService {
         user.softDelete(0L); // TODO: 인증 적용 후 실제 로그인 유저 ID로 교체
     }
 
+    // ✅ POST (포인트 차감)
+    @Transactional
+    public void deductPoints(Long userId, Integer requiredPoints) {
+        User user = findUserById(userId);
+
+        user.deductPoints(requiredPoints);
+    }
+
     // 🔧 중복 검사
     private void validateDuplicateUser(String username, String email) {
         if (userRepository.existsByUsername(username)) {

--- a/user-service/src/main/java/com/fix/user_service/config/WebSecurityConfig.java
+++ b/user-service/src/main/java/com/fix/user_service/config/WebSecurityConfig.java
@@ -28,7 +28,7 @@ public class WebSecurityConfig {
         return http
             .securityMatcher("/**")
             .authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/api/v1/auth/sign-in", "/api/v1/users/sign-up", "/api/v1/auth/user-info/**").permitAll()
+                .requestMatchers("/api/v1/auth/sign-in", "/api/v1/users/sign-up", "api/v1/users/feign/**",  "/api/v1/auth/user-info/**").permitAll()
                 .anyRequest().authenticated()
             )
             .csrf((csrf) -> csrf.disable())

--- a/user-service/src/main/java/com/fix/user_service/domain/User.java
+++ b/user-service/src/main/java/com/fix/user_service/domain/User.java
@@ -2,6 +2,7 @@ package com.fix.user_service.domain;
 
 import com.fix.common_service.entity.UserRole;
 import com.fix.common_service.entity.Basic;
+import com.fix.user_service.application.exception.UserException;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -35,6 +36,8 @@ public class User extends Basic {
     @Column(nullable = false)
     private UserRole roleName;
 
+    private Integer point;
+
 //    빌더 패턴
     @Builder
     private User(String username, String email, String password, String nickname, UserRole roleName) {
@@ -43,6 +46,7 @@ public class User extends Basic {
         this.password = password;
         this.nickname = nickname;
         this.roleName = roleName;
+        this.point = 0;
     }
 
 
@@ -62,5 +66,12 @@ public class User extends Basic {
         this.nickname = nickname;
         this.email = email;
         this.roleName = roleName;
+    }
+
+    public void deductPoints(Integer requiredPoints) {
+        if (this.point < requiredPoints) {
+            throw new UserException(UserException.UserErrorType.NOT_ENOUGH_POINTS);
+        }
+        this.point -= requiredPoints;
     }
 }

--- a/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
@@ -113,6 +113,15 @@ public class UserController {
         return ResponseEntity.ok(CommonResponse.success(null, "사용자가 삭제되었습니다."));
     }
 
+    @PostMapping("/feign/deduct-points/{userId}")
+    public ResponseEntity<CommonResponse<Void>> deductPoints(
+            @PathVariable Long userId,
+            @RequestParam Integer points
+    ) {
+        userService.deductPoints(userId, points);
+        return ResponseEntity.ok(CommonResponse.success(null, "포인트 차감 성공"));
+    }
+
     @GetMapping("/all")
     public ResponseEntity<CommonResponse<UserListResponseDto>> getAllUsers(
             @RequestHeader Map<String, String> headers,


### PR DESCRIPTION
## Description
1.이벤트 엔티티와 유저 도메인에, 응모 조건에 해당하는 '포인트' 필드 변수 정의
2.커스텀 예외 클래스 정의 및 처리
3.권한 처리 (AOP) 및 유저 Id 저장 기능 추가
4.이벤트 서버와 유저 서버의 Feign 연동 (이벤트 응모 시 유저 보유 포인트 차감) 구현

## 변경 타입
- [X] 신규 기능 추가/수정
- [ ] 버그 수정
- [X] 리팩토링
- [ ] 설정
- [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## 변경 내용
- **as-is**
  - 내용 없음

- **to-be**
  - 설명에 적어둔 기능 구현했습니다

## 코멘트
- 현재는 한 명의 유저가 하나의 이벤트에 여러 번 응모를 할 수 있는데, 한 이벤트에 한번만 응모가 가능하도록 할 지, 횟수 제한을 걸어두거나 할 지, 아니면 이대로 냅둘지.. 정책에 관련해서 팀원분들 의견이 궁금합니다.
- 이벤트 응모 취소 기능을 구현할 지 말 지 고민하다 안했는데, 이벤트 응모를 취소하는 기능이 필요할까요? 보통 실제 서비스에선 한번 응모한 이벤트는 취소가 안되는 걸로 기억해서..

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)