### PR TITLE
[FP-165] feat : 좌석 UUID 리스트를 기반으로 가격을 반환하는 Feign 요청 대응 API 구현

### DIFF
--- a/stadium-service/src/main/java/com/fix/stadium_service/application/aop/ValidateUser.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/aop/ValidateUser.java
@@ -1,0 +1,10 @@
+package com.fix.stadium_service.application.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ValidateUser {
+	String[] roles() default {};
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/aop/ValidateUserAspect.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/aop/ValidateUserAspect.java
@@ -1,0 +1,45 @@
+package com.fix.stadium_service.application.aop;
+
+import com.fix.stadium_service.application.exception.StadiumException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+
+@Aspect
+@Component
+@Slf4j
+public class ValidateUserAspect {
+
+	@Around("@annotation(validateUser)")
+	public Object validateUserHeader(ProceedingJoinPoint joinPoint, ValidateUser validateUser) throws Throwable {
+		ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+		HttpServletRequest request = attrs.getRequest();
+
+		String userId = request.getHeader("x-user-id");
+		String userRole = request.getHeader("x-user-role");
+
+		if (userId == null || userRole == null) {
+			log.warn("Missing headers - userId: {}, userRole: {}", userId, userRole);
+			throw new StadiumException(StadiumException.StadiumErrorType.STADIUM_ROLE_UNAUTHORIZED);
+		}
+
+		// 역할 확인
+		String[] allowedRoles = validateUser.roles();
+		boolean authorized = Arrays.stream(allowedRoles)
+			.anyMatch(role -> role.equalsIgnoreCase(userRole));
+
+		if (!authorized) {
+			log.warn("Access denied. userId: {}, role: {}, allowedRoles: {}", userId, userRole, Arrays.toString(allowedRoles));
+			throw new StadiumException(StadiumException.StadiumErrorType.STADIUM_ROLE_UNAUTHORIZED);
+		}
+
+		return joinPoint.proceed();
+	}
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/request/SeatPriceRequestDto.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/request/SeatPriceRequestDto.java
@@ -1,0 +1,19 @@
+package com.fix.stadium_service.application.dtos.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class SeatPriceRequestDto {
+
+    private List<UUID> seatIds;
+
+    public SeatPriceRequestDto(List<UUID> seatIds){
+        this.seatIds = seatIds;
+    }
+
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/response/SeatPriceListResponseDto.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/response/SeatPriceListResponseDto.java
@@ -1,0 +1,19 @@
+package com.fix.stadium_service.application.dtos.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SeatPriceListResponseDto {
+    private List<SeatPriceResponseDto> seatPricesList;
+
+    public SeatPriceListResponseDto(List<SeatPriceResponseDto> seatPricesList) {
+        this.seatPricesList = seatPricesList;
+    }
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/response/SeatPriceResponseDto.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/dtos/response/SeatPriceResponseDto.java
@@ -1,0 +1,19 @@
+package com.fix.stadium_service.application.dtos.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+@Getter
+@Setter
+@NoArgsConstructor
+public class SeatPriceResponseDto {
+    private UUID seatId;
+    private int price;
+
+    public SeatPriceResponseDto(UUID seatId, int price) {
+        this.seatId = seatId;
+        this.price = price;
+    }
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumException.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumException.java
@@ -1,0 +1,32 @@
+package com.fix.stadium_service.application.exception;
+
+import com.fix.common_service.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class StadiumException extends CustomException {
+
+	public StadiumException(StadiumErrorType errorType) {
+		super(errorType.getCode(), errorType.getMessage(), errorType.getStatus());
+	}
+
+
+    @Getter
+	public enum StadiumErrorType {
+		STADIUM_NOT_FOUND("STADIUM_001", HttpStatus.NOT_FOUND, "경기장을 찾을 수 없습니다"),
+		STADIUM_NAME_NOT_FOUND("STADIUM_002", HttpStatus.NOT_FOUND, "해당 팀의 경기장이 존재하지 않습니다."),
+		STADIUM_ROLE_UNAUTHORIZED("STADIUM_003", HttpStatus.UNAUTHORIZED, "경기장 관련 권한이 없습니다");
+
+		private final String code;
+		private final HttpStatus status;
+		private final String message;
+
+		StadiumErrorType(String code, HttpStatus status, String message) {
+			this.code = code;
+			this.status = status;
+			this.message = message;
+		}
+
+    }
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumException.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumException.java
@@ -16,7 +16,9 @@ public class StadiumException extends CustomException {
 	public enum StadiumErrorType {
 		STADIUM_NOT_FOUND("STADIUM_001", HttpStatus.NOT_FOUND, "경기장을 찾을 수 없습니다"),
 		STADIUM_NAME_NOT_FOUND("STADIUM_002", HttpStatus.NOT_FOUND, "해당 팀의 경기장이 존재하지 않습니다."),
-		STADIUM_ROLE_UNAUTHORIZED("STADIUM_003", HttpStatus.UNAUTHORIZED, "경기장 관련 권한이 없습니다");
+		STADIUM_ROLE_UNAUTHORIZED("STADIUM_003", HttpStatus.UNAUTHORIZED, "경기장 관련 권한이 없습니다"),
+		SEAT_NOT_AVAILABLE("STADIUM_004", HttpStatus.BAD_REQUEST, "사용 불가능한 좌석입니다"),
+		SEAT_SECTION_NOT_AVAILABLE("STADIUM_005", HttpStatus.BAD_REQUEST, "사용 불가능한 좌석 구역입니다");
 
 		private final String code;
 		private final HttpStatus status;

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.fix.stadium_service.application.exception;
+
+import com.fix.common_service.dto.CommonResponse;
+import com.fix.stadium_service.domain.model.Stadium;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class StadiumExceptionHandler {
+
+	@ExceptionHandler(exception = {StadiumException.class})
+	public ResponseEntity<CommonResponse<StadiumException>> errorResponse(StadiumException exception) {
+		log.error("[ErrorCode] = {} , [ErrorMessage] = {}", exception.getErrorCode(), exception.getMessage());
+
+		return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
+			exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
+		));
+	}
+
+}

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.fix.stadium_service.application.exception;
 
 import com.fix.common_service.dto.CommonResponse;
-import com.fix.stadium_service.domain.model.Stadium;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
@@ -96,9 +96,9 @@ public class StadiumService {
 
 
     @Transactional
-    public void deleteStadium(Long stadiumId) {
+    public void deleteStadium(Long stadiumId,Long userId) {
         Stadium stadium = findStadium(stadiumId);
-        stadium.softDelete(1L); // userID
+        stadium.softDelete(userId);
     }
 
     @Transactional(readOnly = true)

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
@@ -1,14 +1,10 @@
 package com.fix.stadium_service.application.service;
 
-import com.fix.stadium_service.application.dtos.request.SeatRequestDto;
-import com.fix.stadium_service.application.dtos.request.SeatUpdateRequestDto;
-import com.fix.stadium_service.application.dtos.request.StadiumCreateRequest;
-import com.fix.stadium_service.application.dtos.request.StadiumUpdateRequest;
-import com.fix.stadium_service.application.dtos.response.PageResponseDto;
-import com.fix.stadium_service.application.dtos.response.StadiumFeignResponse;
-import com.fix.stadium_service.application.dtos.response.StadiumResponseDto;
+import com.fix.stadium_service.application.dtos.request.*;
+import com.fix.stadium_service.application.dtos.response.*;
 import com.fix.stadium_service.application.exception.StadiumException;
 import com.fix.stadium_service.domain.model.Seat;
+import com.fix.stadium_service.domain.model.SeatSection;
 import com.fix.stadium_service.domain.model.Stadium;
 import com.fix.stadium_service.domain.model.StadiumName;
 import com.fix.stadium_service.domain.repository.StadiumQueryRepository;
@@ -18,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.UUID;
 
 
 @Service
@@ -58,9 +55,9 @@ public class StadiumService {
                 requestDto.getQuantity()
         );
 
-        if(requestDto.getSeats() != null){
-            for(SeatUpdateRequestDto dto : requestDto.getSeats()){
-                stadium.updateSeat(dto.getSeatId(),dto.getRow(),dto.getNumber(),dto.getSection());
+        if (requestDto.getSeats() != null) {
+            for (SeatUpdateRequestDto dto : requestDto.getSeats()) {
+                stadium.updateSeat(dto.getSeatId(), dto.getRow(), dto.getNumber(), dto.getSection());
             }
         }
 
@@ -86,37 +83,78 @@ public class StadiumService {
 
 
     @Transactional(readOnly = true)
-    public PageResponseDto searchStadiums (StadiumName stadiumName, int page, int size) {
+    public PageResponseDto searchStadiums(StadiumName stadiumName, int page, int size) {
         int offset = page * size;
         List<Stadium> stadiums = stadiumQueryRepository.findByStadiumName(stadiumName, offset, size);
         long totalCount = stadiumQueryRepository.countByStadiumName(stadiumName);
-        return new PageResponseDto(stadiums,page,size,totalCount);
+        return new PageResponseDto(stadiums, page, size, totalCount);
 
     }
 
 
     @Transactional
-    public void deleteStadium(Long stadiumId,Long userId) {
+    public void deleteStadium(Long stadiumId, Long userId) {
         Stadium stadium = findStadium(stadiumId);
         stadium.softDelete(userId);
     }
 
+    // 경기 도메인의 호출
     @Transactional(readOnly = true)
-    public StadiumFeignResponse getStadiumInfoByName(String teamName){
+    public StadiumFeignResponse getStadiumInfoByName(String teamName) {
         StadiumName stadiumName = StadiumName.fromTeamName(teamName);
         Stadium stadium = stadiumRepository.findByStadiumName(stadiumName).orElseThrow(
                 () -> new StadiumException(StadiumException.StadiumErrorType.STADIUM_NAME_NOT_FOUND));
         return StadiumFeignResponse.from(stadium);
     }
 
+    // 티켓 도메인의 호출
+    @Transactional(readOnly = true)
+    public SeatPriceListResponseDto getPrices(SeatPriceRequestDto request) {
 
+        List<UUID> seatIds = request.getSeatIds();
 
+        List<Stadium> stadiums = stadiumRepository.findAll();
 
+        List<SeatPriceResponseDto> seatPrices = stadiums.stream()
+                .flatMap(stadium -> stadium.getSeats().stream())
+                .filter(seat -> seatIds.contains(seat.getSeatId()))
+                .map(seat -> {
+                    if (seat.getIsDeleted()) {
+                        throw new StadiumException(StadiumException.StadiumErrorType.SEAT_NOT_AVAILABLE);
+                    }
+
+                    int price = sectionToPrice(seat.getSection());
+                    return new SeatPriceResponseDto(seat.getSeatId(), price);
+
+                })
+                .toList();
+
+        return new SeatPriceListResponseDto(seatPrices);
+    }
+
+    private int sectionToPrice(SeatSection section) {
+
+        if (section == SeatSection.VIP) {
+            return SeatSection.VIP.getPrice();
+        } else if (section == SeatSection.R_SECTION) {
+            return SeatSection.R_SECTION.getPrice();
+        } else if (section == SeatSection.S_SECTION) {
+            return SeatSection.S_SECTION.getPrice();
+        } else if (section == SeatSection.A_SECTION) {
+            return SeatSection.A_SECTION.getPrice();
+        } else if (section == SeatSection.B_SECTiON) {
+            return SeatSection.B_SECTiON.getPrice();
+        } else if (section == SeatSection.OUTFIELD) {
+            return SeatSection.OUTFIELD.getPrice();
+        } else {
+            throw new StadiumException(StadiumException.StadiumErrorType.SEAT_NOT_AVAILABLE);
+        }
+    }
 
 
     private Stadium findStadium(Long stadiumId) {
         return stadiumRepository.findById(stadiumId)
-                .orElseThrow(() -> new StadiumException(StadiumException.StadiumErrorType.STADIUM_NOT_FOUND));
+                .orElseThrow(() -> new StadiumException(StadiumException.StadiumErrorType.SEAT_SECTION_NOT_AVAILABLE));
     }
 
 

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
@@ -7,6 +7,7 @@ import com.fix.stadium_service.application.dtos.request.StadiumUpdateRequest;
 import com.fix.stadium_service.application.dtos.response.PageResponseDto;
 import com.fix.stadium_service.application.dtos.response.StadiumFeignResponse;
 import com.fix.stadium_service.application.dtos.response.StadiumResponseDto;
+import com.fix.stadium_service.application.exception.StadiumException;
 import com.fix.stadium_service.domain.model.Seat;
 import com.fix.stadium_service.domain.model.Stadium;
 import com.fix.stadium_service.domain.model.StadiumName;
@@ -104,7 +105,7 @@ public class StadiumService {
     public StadiumFeignResponse getStadiumInfoByName(String teamName){
         StadiumName stadiumName = StadiumName.fromTeamName(teamName);
         Stadium stadium = stadiumRepository.findByStadiumName(stadiumName).orElseThrow(
-                () -> new IllegalArgumentException("해당 팀의 경기장이 존재하지 않습니다."));
+                () -> new StadiumException(StadiumException.StadiumErrorType.STADIUM_NAME_NOT_FOUND));
         return StadiumFeignResponse.from(stadium);
     }
 
@@ -115,7 +116,7 @@ public class StadiumService {
 
     private Stadium findStadium(Long stadiumId) {
         return stadiumRepository.findById(stadiumId)
-                .orElseThrow(() -> new IllegalArgumentException("경기장을 찾을 수 없습니다."));
+                .orElseThrow(() -> new StadiumException(StadiumException.StadiumErrorType.STADIUM_NOT_FOUND));
     }
 
 

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/service/StadiumService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.UUID;
+
 
 @Service
 @RequiredArgsConstructor

--- a/stadium-service/src/main/java/com/fix/stadium_service/domain/repository/StadiumRepository.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/domain/repository/StadiumRepository.java
@@ -9,10 +9,17 @@ import java.util.Optional;
 
 public interface StadiumRepository {
     Stadium save(Stadium stadium);
+
     Optional<Stadium> findById(Long id);
+
     List<Stadium> findWithPaging(int offset, int size);
+
     long count();
+
     Optional<Stadium> findByStadiumName(StadiumName stadiumName);
+
+    List<Stadium> findAll();
+
 
 
 }

--- a/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
@@ -2,6 +2,7 @@ package com.fix.stadium_service.presentation.controller;
 
 
 import com.fix.common_service.dto.CommonResponse;
+import com.fix.stadium_service.application.aop.ValidateUser;
 import com.fix.stadium_service.application.dtos.request.StadiumCreateRequest;
 import com.fix.stadium_service.application.dtos.request.StadiumUpdateRequest;
 import com.fix.stadium_service.application.dtos.response.PageResponseDto;
@@ -13,7 +14,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
@@ -23,6 +23,7 @@ public class StadiumController {
     private final StadiumService stadiumService;
 
     // 경기장 생성
+    @ValidateUser(roles = {"MASTER"})
     @PostMapping()
     public ResponseEntity<CommonResponse<StadiumResponseDto>> createStadium(@RequestBody StadiumCreateRequest requestDto) {
         StadiumResponseDto responseDto = stadiumService.createStadium(requestDto);
@@ -45,14 +46,15 @@ public class StadiumController {
         return ResponseEntity.ok(CommonResponse.success(responseDto, "경기장 목록(페이지) 조회 성공"));
     }
 
-
+    @ValidateUser(roles = {"MASTER"})
     @DeleteMapping("/{stadiumId}")
-    public ResponseEntity<CommonResponse<Void>> deleteStadium(@PathVariable("stadiumId") Long stadiumId) {
-        stadiumService.deleteStadium(stadiumId);
+    public ResponseEntity<CommonResponse<Void>> deleteStadium(@PathVariable("stadiumId") Long stadiumId,
+                                                                @RequestHeader("x-user-id")Long userId) {
+        stadiumService.deleteStadium(stadiumId ,userId);
         return ResponseEntity.ok(CommonResponse.success(null, "경기장 삭제 성공"));
 
     }
-
+    @ValidateUser(roles = {"MASTER","MANAGER"})
     @PatchMapping("/{stadiumId}")
     public ResponseEntity<CommonResponse<StadiumResponseDto>> updateStadium(
             @PathVariable Long stadiumId,

--- a/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
@@ -3,9 +3,11 @@ package com.fix.stadium_service.presentation.controller;
 
 import com.fix.common_service.dto.CommonResponse;
 import com.fix.stadium_service.application.aop.ValidateUser;
+import com.fix.stadium_service.application.dtos.request.SeatPriceRequestDto;
 import com.fix.stadium_service.application.dtos.request.StadiumCreateRequest;
 import com.fix.stadium_service.application.dtos.request.StadiumUpdateRequest;
 import com.fix.stadium_service.application.dtos.response.PageResponseDto;
+import com.fix.stadium_service.application.dtos.response.SeatPriceListResponseDto;
 import com.fix.stadium_service.application.dtos.response.StadiumFeignResponse;
 import com.fix.stadium_service.application.dtos.response.StadiumResponseDto;
 import com.fix.stadium_service.application.service.StadiumService;
@@ -23,7 +25,7 @@ public class StadiumController {
     private final StadiumService stadiumService;
 
     // 경기장 생성
-    @ValidateUser(roles = {"MASTER"})
+    //@ValidateUser(roles = {"MASTER"})
     @PostMapping()
     public ResponseEntity<CommonResponse<StadiumResponseDto>> createStadium(@RequestBody StadiumCreateRequest requestDto) {
         StadiumResponseDto responseDto = stadiumService.createStadium(requestDto);
@@ -77,6 +79,11 @@ public class StadiumController {
     @GetMapping("/{home-team}/games")
     public ResponseEntity<StadiumFeignResponse> getStadiumInfo(@PathVariable(name="home-team") String homeTeam){
         return ResponseEntity.ok(stadiumService.getStadiumInfoByName(homeTeam));
+    }
+
+    @PostMapping("feign/get-prices")
+    public SeatPriceListResponseDto getPrices(@RequestBody SeatPriceRequestDto request){
+       return  stadiumService.getPrices(request);
     }
 
 


### PR DESCRIPTION
## 🚀 feat : 좌석 UUID 리스트를 기반으로 가격을 반환하는 Feign 요청 대응 API 구현


---

## 📌 작업 개요
- 좌석 UUID 리스트를 기반으로 좌석의 존재 검증 후 해당 좌석의 SECTION 기반으로 가격을 반환하는 API를 티켓 서버의 요청에 따라서 구현하였습니다.

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 주요 변경 코드 요약
> 핵심적인 로직이 담긴 클래스/메서드/쿼리 등 설명


- `StadiumService.java`  getPrices 메서드 추가 


---

## 🧪 테스트 방법 (선택)
- [x] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):

```http
GET /stadiums/feign/get-prices