### PR TITLE
[FP-114 feat/gamewaiting] 경기 예매 대기열 기능 구현

### DIFF
--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -38,6 +38,12 @@ dependencies {
 	// ✅ PostgreSQL
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// ✅ Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// ✅ WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	// ✅ JSON
 	implementation 'org.json:json:20230227'
 

--- a/game-service/src/main/java/com/fix/game_service/GameServiceApplication.java
+++ b/game-service/src/main/java/com/fix/game_service/GameServiceApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.fix.common_service", "com.fix.game_service"})
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
 @EnableFeignClients
+@EnableScheduling
 public class GameServiceApplication {
 
 	public static void main(String[] args) {

--- a/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
+++ b/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
@@ -15,7 +15,8 @@ public class GameException extends CustomException {
 
 	public enum GameErrorType {
 		GAME_NOT_FOUND("GAME_001", HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다"),
-		GAME_ROLE_UNAUTHORIZED("GAME_002", HttpStatus.UNAUTHORIZED, "경기 관련 권한이 없습니다");
+		GAME_ROLE_UNAUTHORIZED("GAME_002", HttpStatus.UNAUTHORIZED, "경기 관련 권한이 없습니다"),
+		GAME_CANNOT_RESERVATION("GAME_003", HttpStatus.BAD_REQUEST, "경기 예매 가능 시간이 아닙니다");
 
 		private final String code;
 		private final HttpStatus status;

--- a/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
+++ b/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
@@ -16,7 +16,8 @@ public class GameException extends CustomException {
 	public enum GameErrorType {
 		GAME_NOT_FOUND("GAME_001", HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다"),
 		GAME_ROLE_UNAUTHORIZED("GAME_002", HttpStatus.UNAUTHORIZED, "경기 관련 권한이 없습니다"),
-		GAME_CANNOT_RESERVATION("GAME_003", HttpStatus.BAD_REQUEST, "경기 예매 가능 시간이 아닙니다");
+		GAME_CANNOT_RESERVATION("GAME_003", HttpStatus.BAD_REQUEST, "경기 예매 가능 시간이 아닙니다"),
+		GAME_WAITING_ERROR("GAME_004", HttpStatus.BAD_GATEWAY, "경기 대기열과의 접속이 끊어졌습니다");
 
 		private final String code;
 		private final HttpStatus status;

--- a/game-service/src/main/java/com/fix/game_service/application/service/QueueService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/QueueService.java
@@ -1,0 +1,182 @@
+package com.fix.game_service.application.service;
+
+import com.fix.game_service.application.exception.GameException;
+import com.fix.game_service.domain.model.Game;
+import com.fix.game_service.domain.repository.GameRepository;
+import com.fix.game_service.presentation.scheduler.DeactivateGameScheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.fix.game_service.application.exception.GameException.GameErrorType.GAME_CANNOT_RESERVATION;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueService {
+
+	private final GameRepository gameRepository;
+	private final RedisTemplate<String, String> redisTemplate;
+	private final DeactivateGameScheduler deactivateGameScheduler;
+	private final String QUEUE_KEY_PREFIX = "queue:";
+	private final String WORKING_QUEUE_KEY_PREFIX = "queue:working:";
+	private final String ACTIVE_GAMES_KEY = "active-game";
+	private final Long MAX_WORKING_QUEUE_SIZE = 50L;
+	private final int FREE_PASS_LIMIT = 10;
+
+	public Map<String, Object> enterQueue(UUID gameId, Long userId) {
+		// 1. 해당 경기를 찾아서 예매 가능 시간인지 확인
+		Game game = findGame(gameId);
+		if (game.getOpenDate().isAfter(LocalDateTime.now()) ||
+			game.getCloseDate().isBefore(LocalDateTime.now())) {
+			throw new GameException(GAME_CANNOT_RESERVATION);
+		}
+
+		// 2. 입장한 사용자에게 Token 발급
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		String token = UUID.randomUUID().toString();
+
+		// 3. Map에 저장
+		Map<String, Object> response = new HashMap<>();
+		response.put("token", token);
+
+		// 4. 발급한 토큰 Redis에 추가 (대기열)
+		long timestamp = Instant.now().toEpochMilli();
+		redisTemplate.opsForZSet().add(queueKey, token, timestamp);
+
+		// 5. Sorted Set에 추가된 후 순위(대기번호)를 조회하여 반환
+		Long rank = redisTemplate.opsForZSet().rank(queueKey, token);
+
+		// 6. 현재 활성화된 경기 추가
+		registerActiveGame(gameId, game.getStadiumId(), game.getOpenDate(), game.getCloseDate());
+
+		// 7. 대기열에서의 순위 반환
+		response.put("position", rank);
+		log.info("token: {}, rank : {}, userId: {} ", token, rank, userId);
+		return response;
+	}
+
+	/**
+	 * 현재 활성화된 경기 추가
+	 * @param gameId : 경기 ID
+	 * @param stadiumId : 경기장 ID
+	 * @param openDate : 경기 예매 오픈 날짜
+	 * @param closeDate : 경기 예매 마감 날짜
+	 */
+	private void registerActiveGame(UUID gameId, Long stadiumId, LocalDateTime openDate, LocalDateTime closeDate) {
+		redisTemplate.opsForSet().add(ACTIVE_GAMES_KEY, gameId.toString());
+
+		Map<String, String> gameInfo = new HashMap<>();
+		gameInfo.put("stadiumId", stadiumId.toString());
+		gameInfo.put("openDate", openDate.toString());
+		gameInfo.put("closeDate", closeDate.toString());
+		redisTemplate.opsForHash().putAll(ACTIVE_GAMES_KEY + gameId, gameInfo);
+
+		// 등록 시 스케줄링 (closeDate에 맞춰서 활성화 경기 Set에서 경기 제거)
+		deactivateGameScheduler.scheduleUnregister(gameId, closeDate);
+	}
+
+	/**
+	 * 현재 사용자의 대기 순서를 반환
+	 * @param gameId : 경기 ID
+	 * @param token : 대기열 token
+	 * @return : token에 해당하는 순서 반환
+	 */
+	public Long getQueueNumber(UUID gameId, String token) {
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		Long rank = redisTemplate.opsForZSet().rank(queueKey, token);
+		return rank;
+	}
+
+	/**
+	 * 대기열을 떠나는 경우
+	 * @param gameId : 경기 ID
+	 * @param token : 떠나는 사용자의 토큰
+	 */
+	public void leaveQueue(UUID gameId, String token) {
+		String queueKey = "queue:" + gameId;
+		redisTemplate.opsForZSet().remove(queueKey, token);
+	}
+
+	/**
+	 * 대기열을 거치지 않아도 되는가 ?
+	 * @param gameId : 경기 ID
+	 * @return : 대기열을 거치지 않아도 되는지 여부 반환
+	 */
+	public boolean canSkipQueue(UUID gameId) {
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		Long queueSize = redisTemplate.opsForZSet().size(queueKey);
+		return queueSize != null && queueSize < FREE_PASS_LIMIT;
+	}
+
+	/**
+	 * 작업 대기열로 전송
+	 * @param gameId : 대기열로 이동할 게임 ID
+	 * @param token : 대기열로 이동할 토큰
+	 */
+	public void moveToWorkingQueue(UUID gameId, String token) {
+		String workingKey = WORKING_QUEUE_KEY_PREFIX + gameId;
+		redisTemplate.opsForSet().add(workingKey, token);
+		
+		// TODO : 다음 요청으로 전송하는 로직 추가
+		try {
+
+		} finally {
+			// 처리 후 working queue에서 제거
+			redisTemplate.opsForSet().remove(workingKey, token);
+		}
+	}
+
+	/**
+	 * 해당 사용자가 작업 대기열에 존재하는지 확인
+	 * @param gameId : 작업 대기열에 있는지 확인할 경기 ID
+	 * @param token : 확인할 토큰
+	 * @return : 토큰 존재 여부 반환
+	 */
+	public boolean isInWorkingQueue(UUID gameId, String token) {
+		String workingKey = WORKING_QUEUE_KEY_PREFIX + gameId;
+		Boolean result = redisTemplate.opsForSet().isMember(workingKey, token);
+		return Boolean.TRUE.equals(result);
+	}
+
+	/**
+	 * 전체 대기열 Queue의 사이즈 (MASTER 전용)
+	 * @param gameId : 경기 ID
+	 * @return : 경기 ID에 해당하는 전체 대기열 크기 반환
+	 */
+	public Long getQueueSize(UUID gameId) {
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		return redisTemplate.opsForZSet().size(queueKey);
+	}
+
+	/**
+	 * 해당 인원 수 만큼 Queue에 대기가 존재하는지 데이터 확인
+	 * @param gameId : 경기 ID
+	 * @param batchSize : 확인할 인원 수
+	 * @return : 확인 결과 반환
+	 */
+	public Set<String> getRemainUsersInQueue(UUID gameId, int batchSize) {
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		return redisTemplate.opsForZSet().range(queueKey, 0, batchSize - 1);
+	}
+
+	/**
+	 * 경기 검색
+	 * @param gameId : 경기 ID
+	 * @return : 찾아낸 경기 반환
+	 */
+	private Game findGame(UUID gameId) {
+		return gameRepository.findById(gameId)
+			.orElseThrow(() -> new GameException(GameException.GameErrorType.GAME_NOT_FOUND));
+	}
+
+}

--- a/game-service/src/main/java/com/fix/game_service/infrastructure/config/RedisConfig.java
+++ b/game-service/src/main/java/com/fix/game_service/infrastructure/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.fix.game_service.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+		RedisTemplate<String, Object> template = new RedisTemplate<>();
+		template.setConnectionFactory(factory);
+		template.setKeySerializer(new StringRedisSerializer());
+		return template;
+	}
+
+}

--- a/game-service/src/main/java/com/fix/game_service/infrastructure/config/WebSocketConfig.java
+++ b/game-service/src/main/java/com/fix/game_service/infrastructure/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.fix.game_service.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		// WebSocket 연결 endpoint 정의
+		registry.addEndpoint("/ticketing")
+			.setAllowedOriginPatterns("*") // CORS 허용 (배포때는 수정하기)
+			.withSockJS(); // SockJS 지원
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry config) {
+		// 서버가 클라이언트로 메시지 보낼 때 prefix
+		config.enableSimpleBroker("/topic");
+		// 클라이언트에서 서버로 메시지 보낼 때 prefix
+		config.setApplicationDestinationPrefixes("/app");
+	}
+
+}
+

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/QueueController.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/QueueController.java
@@ -1,0 +1,53 @@
+package com.fix.game_service.presentation.controller;
+
+import com.fix.game_service.application.service.QueueService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/games")
+public class QueueController {
+
+	private final QueueService queueService;
+
+	@PostMapping("/{gameId}/enter")
+	public ResponseEntity<Map<String, Object>> enterQueue(@PathVariable UUID gameId, @RequestHeader("x-user-id") Long userId) {
+		Map<String, Object> response = queueService.enterQueue(gameId, userId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/{gameId}/status/{token}")
+	public ResponseEntity<Long> getWaitNumber(@PathVariable UUID gameId, @PathVariable String token) {
+		// 1. 사용자가 작업열에 있는가 ?
+		Boolean isInWorkingQueue = queueService.isInWorkingQueue(gameId, token);
+		if (isInWorkingQueue) {
+			// 다음 API 호출 후 보내주기
+			log.info("token - {}: 다음 화면으로 넘어갑니다", token);
+		}
+		
+		// 2. 작업열에 없다면 대기열에 있는지 파악
+		Long waitNumber = queueService.getQueueNumber(gameId, token);
+
+		// 3. 대기열에 있으면 대기 번호 발급
+		if (waitNumber != null) {
+			return ResponseEntity.ok(waitNumber);
+		// 4. 대기열에도 없다면 오류
+		} else {
+			return ResponseEntity.badRequest().body(0L);
+		}
+	}
+
+	@DeleteMapping("/{gameId}/leave/{token}")
+	public ResponseEntity<Void> leaveQueue(@PathVariable UUID gameId, @PathVariable String token) {
+		queueService.leaveQueue(gameId, token);
+		return ResponseEntity.ok().build();
+	}
+
+}

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/WebSocketQueueController.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/WebSocketQueueController.java
@@ -1,0 +1,56 @@
+package com.fix.game_service.presentation.controller;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import com.fix.game_service.application.service.QueueService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class WebSocketQueueController {
+
+	private final QueueService queueService;
+
+	// TODO : 서버 스케일아웃 시 수정이 필요한 부분 (다른 방법 생각해보기)
+
+	@EventListener
+	public void handleSessionConnect(SessionConnectEvent event) {
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+		String token = accessor.getFirstNativeHeader("token");
+		String gameId = accessor.getFirstNativeHeader("gameId");
+
+		if (token != null && gameId != null) {
+			accessor.getSessionAttributes().put("token", token);
+			accessor.getSessionAttributes().put("gameId", gameId);
+		}
+	}
+
+	@EventListener
+	public void handleSessionDisconnect(SessionDisconnectEvent event) {
+		log.info("세션 접근 종료 이벤트 수신");
+		StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+
+		String token = (String) accessor.getSessionAttributes().get("token");
+		String gameId = (String) accessor.getSessionAttributes().get("gameId");
+
+		if (token != null && gameId != null) {
+			queueService.leaveQueue(UUID.fromString(gameId), token);
+			log.info("대기열에서 제거 완료 : token = " + token);
+		}
+	}
+
+}

--- a/game-service/src/main/java/com/fix/game_service/presentation/scheduler/DeactivateGameScheduler.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/scheduler/DeactivateGameScheduler.java
@@ -1,0 +1,33 @@
+package com.fix.game_service.presentation.scheduler;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeactivateGameScheduler {
+
+	private final RedisTemplate<String, String> redisTemplate;
+	private final String ACTIVE_GAMES_KEY = "active-game";
+	private final TaskScheduler taskScheduler;
+
+	// 해당 경기가 active set에서 자동으로 삭제되도록 하는 메서드
+	public void scheduleUnregister(UUID gameId, LocalDateTime closeDate) {
+		Instant triggerTime = closeDate.atZone(ZoneId.systemDefault()).toInstant();
+
+		taskScheduler.schedule(() -> {
+			redisTemplate.opsForSet().remove(ACTIVE_GAMES_KEY, gameId.toString());
+			log.info("자동 제거됨: {}", gameId);
+		}, triggerTime);
+	}
+}

--- a/game-service/src/main/java/com/fix/game_service/presentation/scheduler/DeactivateGameScheduler.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/scheduler/DeactivateGameScheduler.java
@@ -19,6 +19,8 @@ public class DeactivateGameScheduler {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final String ACTIVE_GAMES_KEY = "active-game";
+	private final String QUEUE_KEY_PREFIX = "queue:";
+
 	private final TaskScheduler taskScheduler;
 
 	// 해당 경기가 active set에서 자동으로 삭제되도록 하는 메서드
@@ -27,6 +29,8 @@ public class DeactivateGameScheduler {
 
 		taskScheduler.schedule(() -> {
 			redisTemplate.opsForSet().remove(ACTIVE_GAMES_KEY, gameId.toString());
+			redisTemplate.delete(QUEUE_KEY_PREFIX + gameId);
+			log.info("대기열 큐 삭제: {}", QUEUE_KEY_PREFIX + gameId);
 			log.info("자동 제거됨: {}", gameId);
 		}, triggerTime);
 	}

--- a/game-service/src/main/java/com/fix/game_service/presentation/scheduler/QueueScheduler.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/scheduler/QueueScheduler.java
@@ -1,0 +1,63 @@
+package com.fix.game_service.presentation.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import com.fix.game_service.application.service.QueueService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QueueScheduler {
+
+	private final QueueService queueService;
+	private final StringRedisTemplate redisTemplate;
+	private final String ACTIVE_GAMES_KEY = "active-game";
+
+	// 한 번에 넘길 사용자 수
+	private final int BATCH_SIZE = 10;
+
+	@Scheduled(initialDelay = 5000, fixedRate = 3000)
+	public void processQueueLogic() {
+		Set<String> gameIdObjects = redisTemplate.opsForSet().members(ACTIVE_GAMES_KEY);
+
+		// 현재 예매중인 경기가 없다면 반환
+		if (gameIdObjects == null || gameIdObjects.isEmpty()) return;
+
+		// 데이터가 있다면,
+		for (Object obj : gameIdObjects) {
+			UUID gameId = UUID.fromString(obj.toString());
+			String infoKey = ACTIVE_GAMES_KEY + gameId;
+
+			Map<Object, Object> gameInfo = redisTemplate.opsForHash().entries(infoKey);
+			if (gameInfo.isEmpty()) continue;
+
+			// 정상 처리: 대기열 → 작업열
+			Set<String> tokens = queueService.getRemainUsersInQueue(gameId, BATCH_SIZE);
+			if (tokens == null || tokens.isEmpty()) continue;
+
+			for (String token : tokens) {
+				log.info("다음 작업열로 이동할 Token: {}", token);
+				try {
+					queueService.moveToWorkingQueue(gameId, token);
+					queueService.leaveQueue(gameId, token);
+				} catch (Exception e) {
+					log.error("입장 처리 실패 [{}]: {}", token, e.getMessage());
+				}
+			}
+		}
+	}
+
+
+}


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)

- 경기 예매 대기열 기능
---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- 경기 예매 버튼 클릭 시, 대기열 기능 구현

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 주요 변경 코드 요약
> 핵심적인 로직이 담긴 클래스/메서드/쿼리 등 설명


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):

```http
POST /api/v1/games/{gameId}/enter