### PR TITLE
[FP-114-feat/gamewaiting] Kafka 및 Redis 캐싱 추가

### DIFF
--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 
 	// ✅ Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	// ✅ WebSocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -10,6 +10,9 @@ dependencies {
 	// ✅ JPA
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+	// ✅ kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+
 	// ✅ QueryDSL
 	implementation "com.querydsl:querydsl-jpa:${querydslVersion}:jakarta"
 	annotationProcessor "com.querydsl:querydsl-apt:${querydslVersion}:jakarta"

--- a/game-service/src/main/java/com/fix/game_service/application/dtos/request/GameTicketRequest.java
+++ b/game-service/src/main/java/com/fix/game_service/application/dtos/request/GameTicketRequest.java
@@ -1,0 +1,19 @@
+package com.fix.game_service.application.dtos.request;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameTicketRequest {
+
+	private UUID gameId;
+	private int quantity;
+
+}

--- a/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
@@ -90,7 +90,7 @@ public class GameService {
 		// 2. homeTeam이 변동되었다면 재요청 필요
 		Game updateGameInfo;
 		if (request.getHomeTeam() != null) {
-			StadiumResponseDto response = stadiumClient.getStadiumInfo(request.getHomeTeam().toString()).getBody();
+			StadiumResponseDto response = getStadiumInfo(request.getHomeTeam().toString());
 			updateGameInfo = request.toGameWithStadium(response.getStadiumId(), response.getStadiumName(), response.getSeatQuantity());
 		} else {
 			updateGameInfo = request.toGame();

--- a/game-service/src/main/java/com/fix/game_service/infrastructure/config/ConsumerKafkaConfig.java
+++ b/game-service/src/main/java/com/fix/game_service/infrastructure/config/ConsumerKafkaConfig.java
@@ -1,0 +1,51 @@
+package com.fix.game_service.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+@EnableKafka
+@Configuration
+public class ConsumerKafkaConfig {
+
+	/**
+	 * Kafka Consumer 인스턴스 생성 시 사용
+	 * @return : 생성한 ConsumerFactory 반환
+	 */
+	@Bean
+	public ConsumerFactory<String, Object> consumerFactory() {
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+		configProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		configProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
+		configProps.put(JsonDeserializer.TRUSTED_PACKAGES, "*"); // 또는 "com.your.package"
+
+		return new DefaultKafkaConsumerFactory<>(
+			configProps,
+			new StringDeserializer(),
+			new JsonDeserializer<>(Object.class) // <- Object로 받기
+		);
+	}
+
+	/**
+	 * KafkaListener가 붙은 메서드들을 실행할 컨테이너 제공
+	 * @return : 리스너에서 사용할 컨테이너 리턴
+	 */
+	@Bean
+	public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+			new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(consumerFactory());
+		return factory;
+	}
+
+}

--- a/game-service/src/main/java/com/fix/game_service/infrastructure/config/RedisConfig.java
+++ b/game-service/src/main/java/com/fix/game_service/infrastructure/config/RedisConfig.java
@@ -1,9 +1,18 @@
 package com.fix.game_service.infrastructure.config;
 
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.CacheKeyPrefix;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -15,6 +24,23 @@ public class RedisConfig {
 		template.setConnectionFactory(factory);
 		template.setKeySerializer(new StringRedisSerializer());
 		return template;
+	}
+
+	@Bean
+	public CacheManager cacheManager(RedisConnectionFactory connectionFactory){
+		// Cache에 저장된 값 직렬화 및 TTL 설정
+		RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeValuesWith(
+				RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer())
+			)
+			.entryTtl(Duration.ofMinutes(120))
+			.disableCachingNullValues();
+
+		// 설정한 CacheConfig 기반으로 RedisCacheManager 생성
+		return RedisCacheManager.builder(connectionFactory)
+			.cacheDefaults(redisCacheConfiguration)
+			.build();
+
 	}
 
 }

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/ConsumerController.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/ConsumerController.java
@@ -1,0 +1,30 @@
+package com.fix.game_service.presentation.controller;
+
+import org.springframework.kafka.annotation.KafkaListener;
+
+import com.fix.game_service.application.dtos.request.GameTicketRequest;
+import com.fix.game_service.application.service.GameService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ConsumerController {
+
+	private final GameService gameService;
+
+	// Kafka에서 메시지를 소비하는 리스너 메서드들을 정의
+	// @KafkaListener 어노테이션은 각 메서드를 Kafka 리스너로 설정
+	@KafkaListener(topics = "game-events", groupId = "group_a")
+	public void consume(Object data) {
+		if (data instanceof GameTicketRequest dto) {
+			log.info("Received DTO: {}", dto);
+			gameService.updateGameSeats(dto.getGameId(), dto.getQuantity());
+		} else {
+			log.warn("Unknown message type: {}", data);
+		}
+	}
+
+}
+


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)

- Kafka Consumer 로직 추가 (추후 수정 필요)
- Redis 캐싱 로직 추가

---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- Kafka Consumer 요청을 받을 로직 추가
- Redis 캐시 데이터를 받아온 후 없으면 Feign 요청을 보내는 로직으로 수정

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트

- Merge 이전에 kafka consumer 쪽 코드를 확인해주시면 좋을 것 같습니다
    - topic을 이전에 다 정해두었는데, 이렇게 적용하는 것이 맞는지 헷갈려서 확인 한 번 부탁드립니다 !
- Redis Caching은 Feign 요청 보내기 이전, Cache 선 확인 후 값이 없다면 Feign 요청을 보내도록 메서드를 따로 두었습니다 
    - 해당 로직도 문제가 있다면 코멘트 부탁드립니다

---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스