### PR TITLE
[FP-195-feat/event] Kafka 도입, 이벤트 기반 비동기 처리 구현 (Event <-> User)

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/dto/EventKafkaMessage.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/EventKafkaMessage.java
@@ -1,0 +1,15 @@
+package com.fix.common_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventKafkaMessage {
+    private String eventType;
+    private EventPayload payload;
+}

--- a/common-service/src/main/java/com/fix/common_service/dto/EventPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/EventPayload.java
@@ -1,0 +1,18 @@
+package com.fix.common_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventPayload {
+    private UUID eventId;      // 이벤트 식별자
+    private Long userId;       // 유저 식별자
+    private Integer points;    // 차감할 포인트
+}

--- a/event-service/build.gradle
+++ b/event-service/build.gradle
@@ -37,6 +37,10 @@ dependencies {
 	// ✅ Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// ✅ Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/producer/EventProducer.java
+++ b/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/producer/EventProducer.java
@@ -1,0 +1,27 @@
+package com.fix.event_service.infrastructure.kafka.producer;
+
+import com.fix.common_service.dto.EventKafkaMessage;
+import com.fix.common_service.dto.EventPayload;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventProducer {
+
+    private final KafkaTemplate<String, EventKafkaMessage> kafkaTemplate;
+
+    public void sendEventApplyRequest(UUID eventId, Long userId, Integer requiredPoints) {
+        EventPayload payload = new EventPayload(eventId, userId, requiredPoints);
+
+        EventKafkaMessage message = new EventKafkaMessage("EVENT_APPLY_REQUEST", payload);
+
+        kafkaTemplate.send("event-apply-topic", message);
+        log.info("[Kafka] EVENT_APPLY_REQUEST 발행: {}", message);
+    }
+}

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -46,6 +46,10 @@ dependencies {
 	// ✅ PostgreSQL
 	implementation 'org.postgresql:postgresql:42.7.2'
 
+	// ✅ Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/UserConsumer.java
+++ b/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/UserConsumer.java
@@ -1,0 +1,32 @@
+package com.fix.user_service.infrastructure.kafka.consumer;
+
+import com.fix.common_service.dto.EventKafkaMessage;
+import com.fix.common_service.dto.EventPayload;
+import com.fix.user_service.application.service.UserService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class UserConsumer {
+
+    private final UserService userService;
+
+    @KafkaListener(topics = "event-apply-topic", groupId = "user-service")
+    public void consumeEventApplyRequest(EventKafkaMessage message) {
+        EventPayload payload = message.getPayload();
+        log.info("[Kafka] EVENT_APPLY_REQUEST 수신: {}", payload);
+
+        try {
+            userService.deductPoints(payload.getUserId(), payload.getPoints());
+            log.info("[Kafka] 포인트 차감 성공: userId={}, points={}", payload.getUserId(), payload.getPoints());
+        } catch (Exception e) {
+            // TODO: 보상 트랜잭션 구현 (차감 실패 이벤트 발행 : 이벤트 응모 취소)
+            log.error("[Kafka] 포인트 차감 실패: eventId={}, userId={}, points={}, error={}",
+                payload.getEventId(), payload.getUserId(), payload.getPoints(), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
Kafka 도입, 이벤트 기반 비동기 처리 구현 (Event <-> User)

---

## 📌 작업 개요
- 기존 Event <-> User의 연동을 Feign을 활용한 동기 호출 방식에서 Kafka를 활용한 비동기 처리 방식으로 개선

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 이전에 Kafka의 토픽 설정을 도메인 별 단일 토픽으로 가져가자고 이야기가 나왔던 것 같은데, 구현 중 이벤트 종류 별로 토픽을 나누는게 맞는 것 같다고 느꼈습니다. 자세한 내용은 따로 정리해두었으니 참고해주세요 ( https://www.notion.so/teamsparta/1c92dc3ef51481aa96e0da1ee146b453?p=1d52dc3ef514808fa46ee9a12c4371bb&pm=s)
- 동작이 잘 되는지 API 테스트를 해봤는데, 기존 Fegin 동기 호출 방식은 실행 시간이 706ms가 나왔었는데 (기록에 있더라구요) 이번에 비동기 방식으로 바꾸고 테스트를 해보니 19ms가 나왔습니다. 생각보다 차이가 큰 것 같기도 하네요
- Consumer 측에서(User 쪽) 계속 수신한 메시지의 직렬화 에러가 발생해서 한참을 삽질했는데, 굉장히 허무하게 해결이 됐습니다. 관련 내용은 따로 정리해두었으니 참고하시고, 저처럼 삽질하시는 일은 없으셨으면 합니다.. (https://www.notion.so/teamsparta/1c92dc3ef51481aa96e0da1ee146b453?p=1d52dc3ef51480dfb3edc4aa73250551&pm=s)


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):