### PR TITLE
[Fp 188 feat/ticket] Kafka 도입, 이벤트 기반 비동기 처리 구현 (Ticket <-> Order, Ticket <-> Game)

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/dto/EventKafkaMessage.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/EventKafkaMessage.java
@@ -1,9 +1,6 @@
 package com.fix.common_service.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
@@ -11,5 +8,5 @@ import lombok.Setter;
 @AllArgsConstructor
 public class EventKafkaMessage {
     private String eventType;
-    private EventPayload payload;
+    private Object payload;
 }

--- a/common-service/src/main/java/com/fix/common_service/dto/OrderCancelledPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/OrderCancelledPayload.java
@@ -1,0 +1,16 @@
+package com.fix.common_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCancelledPayload {
+    private UUID orderId;
+}

--- a/common-service/src/main/java/com/fix/common_service/dto/OrderCreatedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/OrderCreatedPayload.java
@@ -1,0 +1,18 @@
+package com.fix.common_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreatedPayload {
+    private UUID orderId;
+    private List<UUID> ticketIds;
+}

--- a/common-service/src/main/java/com/fix/common_service/dto/TicketReservedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/TicketReservedPayload.java
@@ -1,0 +1,26 @@
+package com.fix.common_service.dto;
+
+import lombok.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TicketReservedPayload {
+    private List<TicketDetail> ticketDetails;
+    private Long userId;
+    private UUID gameId;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TicketDetail {
+        private UUID ticketId;
+        private int price;
+    }
+}

--- a/common-service/src/main/java/com/fix/common_service/dto/TicketReservedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/TicketReservedPayload.java
@@ -9,7 +9,6 @@ import java.util.UUID;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
 public class TicketReservedPayload {
     private List<TicketDetail> ticketDetails;
     private Long userId;

--- a/common-service/src/main/java/com/fix/common_service/dto/TicketUpdatedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/dto/TicketUpdatedPayload.java
@@ -1,0 +1,17 @@
+package com.fix.common_service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketUpdatedPayload {
+    private UUID gameId;
+    private int quantity;
+}

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
+	// ✅ Kafka
+	implementation 'org.springframework.kafka:spring-kafka'
+	testImplementation 'org.springframework.kafka:spring-kafka-test'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
@@ -8,6 +8,7 @@ import com.fix.ticket_service.domain.repository.TicketRepository;
 import com.fix.ticket_service.infrastructure.client.GameClient;
 import com.fix.ticket_service.infrastructure.client.OrderClient;
 import com.fix.ticket_service.infrastructure.client.StadiumClient;
+import com.fix.ticket_service.infrastructure.kafka.producer.TicketProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.RedissonMultiLock;
@@ -36,6 +37,7 @@ public class TicketApplicationService {
     private final GameClient gameClient;
     private final StadiumClient stadiumClient;
     private final RedissonClient redissonClient;
+    private final TicketProducer ticketProducer;
 
     private final RedisTemplate<String, String> redisTemplate;
 
@@ -99,10 +101,9 @@ public class TicketApplicationService {
                 redisTemplate.opsForValue().set(redisKey, "RESERVED", RESERVED_TTL_SECONDS, TimeUnit.SECONDS);
             }
 
-            // 7) Order 서버를 호출하여 주문 생성 및 결제 처리 요청
-            // TODO: 이벤트 발행 방식 비동기 처리
-            OrderCreateRequestDto orderCreateRequestDto = new OrderCreateRequestDto(responseDtoList);
-            orderClient.createOrder(orderCreateRequestDto);
+            // 7) 티켓 예매 이벤트 발행 (주문 생성 요청)
+            ticketProducer.sendTicketReservedEvent(ticketsToSave, userId);
+
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             log.error("락 대기 중 인터럽트 발생: userId={}, seatInfoList={}", userId, request.getSeatInfoList(), e);

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
@@ -201,10 +201,9 @@ public class TicketApplicationService {
             ticket.markAsSold(requestDto.getOrderId());
         }
 
-        // 3) 경기 서버에 잔여 좌석 업데이트(잔여 좌석 차감) 요청
-        // TODO: 이벤트 발행 방식 비동기 처리
+        // 3) 티켓 업데이트 이벤트 발행 (경기 서버에 잔여 좌석 차감 요청)
         int quantity = tickets.size();
-        gameClient.updateRemainingSeats(tickets.get(0).getGameId(), -quantity);
+        ticketProducer.sendTicketUpdatedEvent(tickets.get(0).getGameId(), -quantity);
 
         // 4) Redis 캐시에 SOLD 상태 저장 (TTL = 24시간)
         for (Ticket ticket : tickets) {
@@ -223,10 +222,9 @@ public class TicketApplicationService {
             ticket.markAsCancelled();
         }
 
-        // 3) 경기 서버에 잔여 좌석 업데이트(잔여 좌석 증가) 요청
-        // TODO: 이벤트 발행 방식 비동기 처리
+        // 3) 티켓 업데이트 이벤트 발행 (경기 서버에 잔여 좌석 증가 요청)
         int quantity = tickets.size();
-        gameClient.updateRemainingSeats(tickets.get(0).getGameId(), quantity);
+        ticketProducer.sendTicketUpdatedEvent(tickets.get(0).getGameId(), quantity);
 
         // 4) Redis 캐시에서 해당 좌석 키 삭제
         for (Ticket ticket : tickets) {

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketConsumer.java
@@ -1,0 +1,54 @@
+package com.fix.ticket_service.infrastructure.kafka.consumer;
+
+import com.fix.common_service.dto.EventKafkaMessage;
+import com.fix.common_service.dto.OrderCancelledPayload;
+import com.fix.common_service.dto.OrderCreatedPayload;
+import com.fix.ticket_service.application.dtos.request.TicketSoldRequestDto;
+import com.fix.ticket_service.application.service.TicketApplicationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketConsumer {
+
+    private final TicketApplicationService ticketApplicationService;
+
+    // topic 명은 주문에서 이벤트를 발행한다고 가정하고 설정, 결제에서 발행한다면 수정 필요
+    @KafkaListener(topics = "order-created-topic", groupId = "ticket-service-group")
+    public void consumeOrderCreatedEvent(EventKafkaMessage eventMessage) {
+        OrderCreatedPayload payload = (OrderCreatedPayload) eventMessage.getPayload();
+        log.info("[Kafka] 주문 생성 이벤트 수신: {}", payload);
+
+        TicketSoldRequestDto requestDto = new TicketSoldRequestDto(payload.getOrderId(), payload.getTicketIds());
+        try {
+            ticketApplicationService.updateTicketStatus(requestDto);
+            log.info("[Kafka] 티켓 판매 상태 업데이트 성공: orderId={}, ticketIds={}",
+                requestDto.getOrderId(), requestDto.getTicketIds());
+        } catch (Exception e) {
+            // TODO: 보상 트랜잭션 구현
+            log.info("[Kafka] 티켓 판매 상태 업데이트 실패: orderId={}, ticketIds={}",
+                requestDto.getOrderId(), requestDto.getTicketIds());
+        }
+    }
+
+    @KafkaListener(topics = "order-cancelled-topic", groupId = "ticket-service-group")
+    public void consumeOrderCancelledEvent(EventKafkaMessage eventMessage) {
+        OrderCancelledPayload payload = (OrderCancelledPayload) eventMessage.getPayload();
+        log.info("[Kafka] 주문 취소 이벤트 수신: {}", payload);
+
+        UUID orderId = payload.getOrderId();
+        try {
+            ticketApplicationService.cancelTicketStatus(orderId);
+            log.info("[Kafka] 티켓 취소 상태 업데이트 성공: orderId={}", orderId);
+        } catch (Exception e) {
+            // TODO: 보상 트랜잭션 구현
+            log.info("[Kafka] 티켓 취소 상태 업데이트 실패: orderId={}", orderId);
+        }
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
@@ -2,6 +2,7 @@ package com.fix.ticket_service.infrastructure.kafka.producer;
 
 import com.fix.common_service.dto.EventKafkaMessage;
 import com.fix.common_service.dto.TicketReservedPayload;
+import com.fix.common_service.dto.TicketUpdatedPayload;
 import com.fix.ticket_service.domain.model.Ticket;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -9,6 +10,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -26,5 +28,13 @@ public class TicketProducer {
         EventKafkaMessage eventMessage = new EventKafkaMessage("TICKET_RESERVED", payload);
         kafkaTemplate.send("ticket-reserved-topic", eventMessage);
         log.info("[Kafka] TICKET_RESERVED 이벤트 발행: {}", eventMessage);
+    }
+
+    public void sendTicketUpdatedEvent(UUID gameId, int quantity) {
+        TicketUpdatedPayload payload = new TicketUpdatedPayload(gameId, quantity);
+
+        EventKafkaMessage eventMessage = new EventKafkaMessage("TICKET_UPDATED", payload);
+        kafkaTemplate.send("ticket-updated-topic", eventMessage);
+        log.info("[Kafka] TICKET_UPDATED 이벤트 발행: {}", eventMessage);
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
@@ -1,0 +1,30 @@
+package com.fix.ticket_service.infrastructure.kafka.producer;
+
+import com.fix.common_service.dto.EventKafkaMessage;
+import com.fix.common_service.dto.TicketReservedPayload;
+import com.fix.ticket_service.domain.model.Ticket;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TicketProducer {
+
+    private final KafkaTemplate<String, EventKafkaMessage> kafkaTemplate;
+
+    public void sendTicketReservedEvent(List<Ticket> tickets, Long userId) {
+        List<TicketReservedPayload.TicketDetail> ticketDetails = tickets.stream()
+                .map(ticket -> new TicketReservedPayload.TicketDetail(ticket.getTicketId(), ticket.getPrice()))
+                .toList();
+        TicketReservedPayload payload = new TicketReservedPayload(ticketDetails, userId, tickets.get(0).getGameId());
+
+        EventKafkaMessage eventMessage = new EventKafkaMessage("TICKET_RESERVED", payload);
+        kafkaTemplate.send("ticket-reserved-topic", eventMessage);
+        log.info("[Kafka] TICKET_RESERVED 이벤트 발행: {}", eventMessage);
+    }
+}


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
Kafka 도입, 이벤트 기반 비동기 처리 구현 (Ticket <-> Order, Ticket <-> Game)

---

## 📌 작업 개요
- Kafka 이벤트 발행에 사용될 공통 Dto (EventKafkaMessage) 정의
- Ticket <-> Order 기존 Feign 방식의 연동 => 이벤트 기반 비동기 처리
- Ticket <-> Game 기존 Feign 방식의 연동 => 이벤트 기반 비동기 처리

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 이벤트 발행에 사용될 공통 Dto(EventKafkaMessage)를 정의했습니다. 해당 공통 Dto를 사용하게 되면 모든 이벤트 발행, 수신 양쪽에서 같은 객체를 사용하기 때문에 타입 불일치로 생기는 에러(지긋지긋 합니다..)를 방지할 수 있을 것 같고, 정의해둔 Dto를 가져다 쓰기만 하면 되기 때문에 개발 편의성도 올라갈 것 같습니다. 팀원분들은 어떻게 생각하시나요?
- topic 네이밍을 어떻게 할까 하다가, 이벤트를 발행하는 도메인을 기준으로 이름 지어봤습니다. (Order가 발행하는 이벤트 토픽 : order-created-topic, Ticket이 발행하는 이벤트 토픽 : ticket-reserved-topic 등) 이 부분도 합의가 필요할 것 같으니 팀원분들 의견 부탁드립니다.
- 이벤트 발행에 사용하는 페이로드 Dto(공통 Dto 내부 실제 데이터가 담긴 페이로드)는 '토픽 명+Payload'로 네이밍했습니다. (예시 : TicketReservedPayload)
- Ticket 도메인에서 이벤트 발행 및 수신에 사용되는 객체들은 모두 Common 모듈에 정의해 놓았습니다. (필요하시면 주입 받아 사용하시면 됩니다)


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):