### PR TITLE
[Event] fix : 보상 트랜잭션 관련 버그 수정

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="CompilerConfiguration">
     <annotationProcessing>
+      <profile default="true" name="Default" enabled="true" />
       <profile name="Gradle Imported" enabled="true">
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">

--- a/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/EventApplicationService.java
@@ -14,6 +14,7 @@ import com.fix.event_service.domain.service.EventDomainService;
 import com.fix.event_service.infrastructure.client.UserClient;
 import com.fix.event_service.infrastructure.kafka.producer.EventProducer;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -28,6 +29,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EventApplicationService {
 
     private final EventRepository eventRepository;

--- a/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
+++ b/event-service/src/main/java/com/fix/event_service/domain/model/Event.java
@@ -36,7 +36,7 @@ public class Event extends Basic {
     @OneToOne(mappedBy = "event", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private Reward reward;
 
-    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "event", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<EventEntry> entries = new ArrayList<>();
 
     @Builder
@@ -131,6 +131,7 @@ public class Event extends Basic {
 
     public void removeEntry(EventEntry eventEntry) {
         if (this.entries != null) {
+            eventEntry.setEvent(null);
             this.entries.remove(eventEntry);
         }
     }

--- a/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
@@ -33,7 +33,7 @@ public class EventController {
     public ResponseEntity<CommonResponse<Void>> applyEvent(
         @PathVariable("eventId") UUID eventId, @RequestHeader("x-user-id") Long userId) {
         eventApplicationService.applyEvent(eventId, userId);
-        return ResponseEntity.ok(CommonResponse.success(null, "이벤트 응모 성공"));
+        return ResponseEntity.ok(CommonResponse.success(null, "이벤트 응모 신청 성공"));
     }
 
     // ✅ 이벤트 단건 상세 조회 API


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
보상 트랜잭션 관련 버그 수정

---

## 📌 작업 개요
- 보상 트랜잭션 후 EventEntry 가 제거되지 않는 버그 : 연관관계 설정 누락

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 이벤트 응모 포인트 차감 시, 유저의 잔여 포인트가 부족할 경우 생성한 EventEntry를 제거하는 보상 트랜잭션이 제대로 동작하지 않는 버그가 있었는데(DB에 엔티티가 남아있음), 연관 관계 설정에서 고아 엔티티 제거 옵션을 넣지 않아서 생긴 문제였습니다. (간단한 문제였어서 다행이네요..)


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):
