### PR TITLE
[FP-196-feat/chatting] 채팅 처리 로직 수정

### DIFF
--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -23,6 +23,9 @@ dependencies {
     // ✅ WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
+    // ✅ Afterburner
+    implementation 'com.fasterxml.jackson.module:jackson-module-afterburner'
+
     // ✅ Json
     implementation 'org.json:json:20210307'
 

--- a/chat-service/src/main/java/com/fix/chat_service/application/dtos/ChatMessage.java
+++ b/chat-service/src/main/java/com/fix/chat_service/application/dtos/ChatMessage.java
@@ -1,0 +1,30 @@
+package com.fix.chat_service.application.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessage {
+
+    private String chatId;
+    private String nickname;
+    private String message;
+    private LocalDateTime time;
+    private String type;
+
+    public void setMessageType(String type) {
+        this.type = type;
+    }
+
+    public void setChatId(String chatId) {
+        this.chatId = chatId;
+    }
+
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaConsumerConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaConsumerConfig.java
@@ -1,0 +1,72 @@
+package com.fix.chat_service.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.chat_service.application.dtos.ChatMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableKafka
+@RequiredArgsConstructor
+public class KafkaConsumerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.properties.spring.json.trusted.packages}")
+    private String trustedPackages;
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Kafka Consumer 기본 설정
+     * @return : 기본 설정 반환
+     */
+    @Bean
+    public ConsumerFactory<String, ChatMessage> consumerConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);  // Kafka 서버 주소
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "chat-service");  // Consumer Group ID
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);  // Key Deserializer
+
+        // Value Deserializer: JSON 사용 + 에러 핸들링 추가
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class); // 에러 핸들링 Deserializer 사용
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class); // 실제 사용할 Deserializer 지정
+
+        // JsonDeserializer 설정
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, trustedPackages);
+        props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, ChatMessage.class.getName()); // 기본 역직렬화 타입
+        props.put(JsonDeserializer.USE_TYPE_INFO_HEADERS, "true");
+
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"); // 처음 연결 시 가장 오래된 메시지부터
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // 수동 또는 리스너 컨테이너 커밋 사용
+
+        JsonDeserializer<ChatMessage> valueDeserializer = new JsonDeserializer<>(ChatMessage.class, objectMapper);
+
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), valueDeserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, ChatMessage> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChatMessage> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerConfig());
+        return factory;
+    }
+    
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaProducerConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaProducerConfig.java
@@ -25,6 +25,22 @@ public class KafkaProducerConfig {
     @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
+    @Value("${spring.kafka.producer.acks}")
+    private String acks;
+
+    @Value("${spring.kafka.producer.retries}")
+    private Integer retries;
+
+    @Value("${spring.kafka.producer.batch-size}")
+    private Integer batchSize;
+
+    @Value("${spring.kafka.producer.linger-ms}")
+    private Integer lingerMs;
+
+    @Value("${spring.kafka.producer.request-timeout}")
+    private Integer requestTimeout;
+
+
     private final ObjectMapper objectMapper;
 
     @Bean
@@ -33,7 +49,12 @@ public class KafkaProducerConfig {
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-        props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        props.put(ProducerConfig.ACKS_CONFIG, acks); // 모든 리더-팔로워에 반영 시 ack
+        props.put(ProducerConfig.RETRIES_CONFIG, retries);  // 재시도 횟수
+        props.put(ProducerConfig.LINGER_MS_CONFIG, lingerMs); // batching 지연시간
+        props.put(ProducerConfig.BATCH_SIZE_CONFIG, batchSize); // 배치 사이즈
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, requestTimeout); // 요청 타임아웃
 
         JsonSerializer<ChatMessage> valueSerializer = new JsonSerializer<>(objectMapper);
         return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), valueSerializer);

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaProducerConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/KafkaProducerConfig.java
@@ -1,0 +1,47 @@
+package com.fix.chat_service.infrastructure.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.chat_service.application.dtos.ChatMessage;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public ProducerFactory<String, ChatMessage> producerConfig() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+
+        JsonSerializer<ChatMessage> valueSerializer = new JsonSerializer<>(objectMapper);
+        return new DefaultKafkaProducerFactory<>(props, new StringSerializer(), valueSerializer);
+    }
+
+    @Bean
+    public KafkaTemplate<String, ChatMessage> customKafkaTemplate() {
+        return new KafkaTemplate<>(producerConfig());
+    }
+
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 @Configuration
 public class ObjectMapperConfig {
@@ -13,7 +14,8 @@ public class ObjectMapperConfig {
     @Bean
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule()); // JavaTimeModule 등록
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.registerModule(new AfterburnerModule());
         objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         return objectMapper;
     }

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
@@ -1,0 +1,21 @@
+package com.fix.chat_service.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // JavaTimeModule 등록
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/WebSocketConfig.java
@@ -1,10 +1,11 @@
 package com.fix.chat_service.infrastructure.config;
 
-import com.fix.chat_service.infrastructure.handler.CustomWebSocketHandler;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+import com.fix.chat_service.infrastructure.handler.CustomWebSocketHandler;
 
 import lombok.RequiredArgsConstructor;
 

--- a/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatMessageConsumer.java
+++ b/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatMessageConsumer.java
@@ -3,10 +3,11 @@ package com.fix.chat_service.presenatation.consumer;
 import java.io.IOException;
 import java.util.UUID;
 
-import org.json.JSONObject;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.chat_service.application.dtos.ChatMessage;
 import com.fix.chat_service.infrastructure.handler.CustomWebSocketHandler;
 
 import lombok.RequiredArgsConstructor;
@@ -18,17 +19,18 @@ import lombok.extern.slf4j.Slf4j;
 public class ChatMessageConsumer {
 
 	private final CustomWebSocketHandler webSocketHandler;
+	private final ObjectMapper objectMapper;
 
 	/**
 	 * 토픽으로 메시지 전송
 	 * @param message : 받은 메시지 해당 채팅방으로 전달
 	 */
 	@KafkaListener(topics = "chat-message", groupId = "chat-service")
-	public void consume(String message) throws IOException {
-		JSONObject json = new JSONObject(message);
-		String chatIdStr = json.getString("chatId");
+	public void consumeMessage(ChatMessage message) throws IOException {
+		// 로그 저장 등의 로직이 필요하다면 ChatMessage로 캐스팅 과정 필요
+		// ChatMessage chatMessage = objectMapper.readValue(message, ChatMessage.class);
 
 		// 메시지 브로드캐스트
-		webSocketHandler.broadcastMessage(UUID.fromString(chatIdStr), message);
+		webSocketHandler.broadcastMessage(UUID.fromString(message.getChatId()), message);
 	}
 }

--- a/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatMessageConsumer.java
+++ b/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatMessageConsumer.java
@@ -25,7 +25,7 @@ public class ChatMessageConsumer {
 	 * 토픽으로 메시지 전송
 	 * @param message : 받은 메시지 해당 채팅방으로 전달
 	 */
-	@KafkaListener(topics = "chat-message", groupId = "chat-service")
+	@KafkaListener(topics = "chat-message", groupId = "${spring.kafka.consumer.group-id}")
 	public void consumeMessage(ChatMessage message) throws IOException {
 		// 로그 저장 등의 로직이 필요하다면 ChatMessage로 캐스팅 과정 필요
 		// ChatMessage chatMessage = objectMapper.readValue(message, ChatMessage.class);

--- a/chat-service/src/main/java/com/fix/chat_service/presenatation/producer/ChatMessageProducer.java
+++ b/chat-service/src/main/java/com/fix/chat_service/presenatation/producer/ChatMessageProducer.java
@@ -3,6 +3,10 @@ package com.fix.chat_service.presenatation.producer;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.chat_service.application.dtos.ChatMessage;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -11,15 +15,17 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ChatMessageProducer {
 
-	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final KafkaTemplate<String, ChatMessage> kafkaTemplate;
+	private final ObjectMapper objectMapper;
 
 	/**
 	 * 해당 토픽으로 메시지 수신
 	 * @param topic : 토픽명
-	 * @param message : 전달할 메시지
+	 * @param chatMessage : 전달할 메시지
 	 */
-	public void sendMessage(String topic, String message) {
-		kafkaTemplate.send(topic, message);
+	public void sendMessage(String topic, ChatMessage chatMessage) throws JsonProcessingException {
+		// String message = objectMapper.writeValueAsString(chatMessage);
+		kafkaTemplate.send(topic, chatMessage);
 	}
 }
 

--- a/chat-service/src/main/java/com/fix/chat_service/presenatation/producer/ChatMessageProducer.java
+++ b/chat-service/src/main/java/com/fix/chat_service/presenatation/producer/ChatMessageProducer.java
@@ -1,6 +1,9 @@
 package com.fix.chat_service.presenatation.producer;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -25,7 +28,18 @@ public class ChatMessageProducer {
 	 */
 	public void sendMessage(String topic, ChatMessage chatMessage) throws JsonProcessingException {
 		// String message = objectMapper.writeValueAsString(chatMessage);
-		kafkaTemplate.send(topic, chatMessage);
+		// kafkaTemplate.send(topic, chatMessage);
+		CompletableFuture<SendResult<String, ChatMessage>> future =
+			kafkaTemplate.send(topic, chatMessage);
+
+		future.whenComplete((result, ex) -> {
+			if (ex != null) {
+				System.err.println("Kafka 전송 실패: " + ex.getMessage());
+			} else {
+				System.out.println("Kafka 전송 성공: " + result.getRecordMetadata().offset());
+			}
+		});
+
 	}
 }
 


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
- 채팅 처리 로직 수정

---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- 채팅 메시지 구조 적용
- ObjectMapper에 AfterBurner 추가
- websocket -> Kafka -> websocket 처리 로직 수정

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트

- 채팅 메시지 구조를 적용하고, 처리 로직을 수정했습니다.
- 관련해서 의견이나 코멘트 남겨주시면 반영하겠습니다 !

---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):

```http
GET /stadiums/search?name=JAMSIL