### PR TITLE
[FP-196-feat/chatting] 사용자 정보 받아오는 로직 추가

### DIFF
--- a/chat-service/src/main/java/com/fix/chat_service/application/dtos/ChatMessage.java
+++ b/chat-service/src/main/java/com/fix/chat_service/application/dtos/ChatMessage.java
@@ -27,4 +27,7 @@ public class ChatMessage {
         this.chatId = chatId;
     }
 
+	public void setNickname(String nickname) {
+	    this.nickname = nickname;
+    }
 }

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/client/UserClient.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/client/UserClient.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 @FeignClient(name = "user-service")
 public interface UserClient {
 
-	@GetMapping("/api/v1/users/{userId}/chat")
+	@GetMapping("/api/v1/users/feign/{userId}/chat")
 	String getNickname(@PathVariable Long userId);
 
 }

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/client/UserClient.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/client/UserClient.java
@@ -1,0 +1,13 @@
+package com.fix.chat_service.infrastructure.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service")
+public interface UserClient {
+
+	@GetMapping("/api/v1/users/{userId}/chat")
+	String getNickname(@PathVariable Long userId);
+
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/WebSocketConfig.java
@@ -5,6 +5,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 
+import com.fix.chat_service.infrastructure.handler.CustomHandshakeInterceptor;
 import com.fix.chat_service.infrastructure.handler.CustomWebSocketHandler;
 
 import lombok.RequiredArgsConstructor;
@@ -15,10 +16,12 @@ import lombok.RequiredArgsConstructor;
 public class WebSocketConfig implements WebSocketConfigurer {
 
 	private final CustomWebSocketHandler customWebSocketHandler;
+	private final CustomHandshakeInterceptor customHandshakeInterceptor;
 
 	@Override
 	public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
 		registry.addHandler(customWebSocketHandler, "/ws-chat/**")
+			.addInterceptors(customHandshakeInterceptor)
 			.setAllowedOrigins("*");
 	}
 

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomHandshakeInterceptor.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomHandshakeInterceptor.java
@@ -27,10 +27,12 @@ public class CustomHandshakeInterceptor implements HandshakeInterceptor {
 
 		if (request instanceof ServletServerHttpRequest servletServerHttpRequest) {
 			String userId = servletServerHttpRequest.getServletRequest().getHeader("x-user-id");
+			log.info("userID: {}" ,userId);
 
 			if (userId != null) {
 				try {
 					String nickname = userClient.getNickname(Long.valueOf(userId));
+					log.info(nickname);
 					attributes.put("nickname", nickname);
 				} catch (Exception e) {
 					attributes.put("nickname", "Anonymous");

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomHandshakeInterceptor.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomHandshakeInterceptor.java
@@ -1,0 +1,46 @@
+package com.fix.chat_service.infrastructure.handler;
+
+import java.util.Map;
+
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import com.fix.chat_service.infrastructure.client.UserClient;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomHandshakeInterceptor implements HandshakeInterceptor {
+
+	private final UserClient userClient;
+
+	@Override
+	public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response,
+		WebSocketHandler wsHandler, Map<String, Object> attributes) throws Exception {
+
+		if (request instanceof ServletServerHttpRequest servletServerHttpRequest) {
+			String userId = servletServerHttpRequest.getServletRequest().getHeader("x-user-id");
+
+			if (userId != null) {
+				try {
+					String nickname = userClient.getNickname(Long.valueOf(userId));
+					attributes.put("nickname", nickname);
+				} catch (Exception e) {
+					attributes.put("nickname", "Anonymous");
+				}
+			}
+		}
+		return true;
+	}
+
+	@Override
+	public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response,
+		WebSocketHandler wsHandler, Exception exception) {}
+}

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomWebSocketHandler.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomWebSocketHandler.java
@@ -53,8 +53,10 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
 	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
 		UUID chatId = getChatId(session);
 		ChatMessage chatMessage = objectMapper.readValue(message.getPayload(), ChatMessage.class);
+		String nickname = (String) session.getAttributes().get("nickname");
 		chatMessage.setMessageType("USER");
 		chatMessage.setChatId(chatId.toString());
+		chatMessage.setNickname(nickname);
 		producer.sendMessage("chat-message", chatMessage);
 	}
 

--- a/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
+++ b/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
@@ -124,7 +124,9 @@ public class UserService {
 
     // 닉네임 반환
     public String getNickname(Long userId) {
+        System.out.println("사용자 ID : " + userId);
         User user = findUserById(userId);
+        System.out.println("사용자 닉네임 : " + user.getNickname());
         return user.getNickname();
     }
     

--- a/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
+++ b/user-service/src/main/java/com/fix/user_service/application/service/UserService.java
@@ -122,6 +122,12 @@ public class UserService {
         }
     }
 
+    // 닉네임 반환
+    public String getNickname(Long userId) {
+        User user = findUserById(userId);
+        return user.getNickname();
+    }
+    
     // 사용자 조회 공통 메서드
     private User findUserById(Long userId) {
         return userRepository.findById(userId)

--- a/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
@@ -153,8 +153,9 @@ public class UserController {
         ));
     }
 
-    @GetMapping("/{userId}/chat")
+    @GetMapping("/feign/{userId}/chat")
     public String getNickname(@PathVariable Long userId) {
+        log.info("채팅에서 받은 요청: {}" , userId);
         return userService.getNickname(userId);
     }
 

--- a/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
@@ -153,6 +153,11 @@ public class UserController {
         ));
     }
 
+    @GetMapping("/{userId}/chat")
+    public String getNickname(@PathVariable Long userId) {
+        return userService.getNickname(userId);
+    }
+
     private Map<String, Object> ValidationErrorResponse(BindingResult bindingResult) {
         List<Map<String, String>> errors = bindingResult.getFieldErrors().stream()
             .map(fieldError -> Map.of(


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)

- 사용자 정보를 받아 nickname을 가져오는 로직 추가

---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- 닉네임을 직접 받아오는 것에서 로그인한 사용자의 정보를 받아와 닉네임을 처리하는 것으로 수정

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 해당 내용 관련해서 더 좋은 의견이 있다면 코멘트 부탁드립니다


---

## 🧪 테스트 방법 (선택)
- [X] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스