### PR TITLE
[Fp 258 feat/logging] 코드 레벨 로그 구성

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/aop/ApiLogging.java
+++ b/common-service/src/main/java/com/fix/common_service/aop/ApiLogging.java
@@ -1,0 +1,9 @@
+package com.fix.common_service.aop;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ApiLogging {
+}

--- a/common-service/src/main/java/com/fix/common_service/aop/ApiLoggingAspect.java
+++ b/common-service/src/main/java/com/fix/common_service/aop/ApiLoggingAspect.java
@@ -1,0 +1,108 @@
+package com.fix.common_service.aop;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ApiLoggingAspect {
+
+    private final ObjectMapper objectMapper;
+    private static final String TRACE_ID = "traceId";
+
+    @Around("@annotation(com.fix.common_service.aop.ApiLogging)")
+    public Object logApiCall(ProceedingJoinPoint joinPoint) throws Throwable {
+        long startTime = System.currentTimeMillis();
+        String traceId = MDC.get(TRACE_ID);
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        String methodName = signature.getMethod().getName();
+
+        HttpServletRequest request =
+            ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        String requestURI = request.getRequestURI();
+        String httpMethod = request.getMethod();
+
+        String userId = request.getHeader("x-user-id");
+        String userRole = request.getHeader("x-user-role");
+
+        if (userId == null) userId = "UNKNOWN_USER";
+        if (userRole == null) userRole = "UNKNOWN_ROLE";
+
+        String paramsJson = "";
+        try {
+            paramsJson = paramsToString(joinPoint.getArgs(), signature.getParameterNames());
+        } catch (Exception e) {
+            log.warn("[{}] API 요청 파라미터 JSON 변환 오류: {}", traceId, e.getMessage());
+        }
+
+        log.info("[{}] API START: userId={}, userRole={}, {} {} | Method={}.{} | Params={}",
+            traceId, userId, userRole, httpMethod, requestURI, className, methodName, paramsJson);
+
+        Object result;
+        try {
+            result = joinPoint.proceed();
+            return result;
+        } catch (Throwable throwable) {
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            log.error("[{}] API ERROR: userId={}, userRole={}, {} {} | Method={}.{} | Duration={}ms | Error={}",
+                traceId, userId, userRole, httpMethod, requestURI, className, methodName, duration, throwable.getMessage(), throwable);
+            throw throwable; // 예외를 다시 던져서 호출자에게 전달
+        } finally {
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+            log.info("[{}] API END: userId={}, userRole={}, {} {} | Method={}.{} | Duration={}ms",
+                traceId, userId, userRole, httpMethod, requestURI, className, methodName, duration);
+        }
+    }
+
+    // 메서드 파라미터를 안전하게 문자열(JSON)으로 변환하는 메서드
+    private String paramsToString(Object[] params, String[] paramNames) {
+        if (params == null || params.length == 0) {
+            return "NONE";
+        }
+        Map<String, Object> paramMap = new HashMap<>();
+        for (int i = 0; i < params.length; i++) {
+            String name = paramNames[i];
+            Object value = params[i];
+
+            // 민감 정보, HttpServletRequest/Response, BindingResult 등 로깅 제외/마스킹
+            if (name.toLowerCase().contains("password") ||
+                value instanceof jakarta.servlet.ServletRequest ||
+                value instanceof jakarta.servlet.ServletResponse ||
+                value instanceof org.springframework.web.multipart.MultipartFile ||
+                value instanceof org.springframework.ui.Model ||
+                value instanceof org.springframework.validation.BindingResult) {
+                paramMap.put(name, "*** MASKED / EXCLUDED ***");
+            } else {
+                paramMap.put(name, value);
+            }
+        }
+        try {
+            // 너무 큰 요청 로깅 방지 (2000자 제한)
+            String json = objectMapper.writeValueAsString(paramMap);
+            if (json.length() > 2000) {
+                return json.substring(0, 2000) + "...(truncated)";
+            }
+            return json;
+        } catch (Exception e) {
+            return "Params serialization failed: " + e.getMessage();
+        }
+    }
+}

--- a/common-service/src/main/java/com/fix/common_service/config/AppConfig.java
+++ b/common-service/src/main/java/com/fix/common_service/config/AppConfig.java
@@ -1,0 +1,19 @@
+package com.fix.common_service.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
+    }
+}

--- a/event-service/build.gradle
+++ b/event-service/build.gradle
@@ -41,6 +41,14 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
+++ b/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
@@ -15,7 +15,7 @@ public class EventExceptionHandler {
 	@ExceptionHandler(exception = {EventException.class})
 	public ResponseEntity<CommonResponse<EventException>> errorResponse(
 		EventException exception, HttpServletRequest request) {
-		log.error("EventException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+		log.warn("EventException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
 			request.getRequestURI(), request.getMethod(),
 			exception.getErrorCode(), exception.getMessage());
 
@@ -27,7 +27,7 @@ public class EventExceptionHandler {
 	@ExceptionHandler(exception = {IllegalArgumentException.class})
 	public ResponseEntity<CommonResponse<String>> illegalArgumentException(
 		IllegalArgumentException exception, HttpServletRequest request) {
-		log.error("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+		log.warn("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
 			request.getRequestURI(), request.getMethod(), exception.getMessage());
 
 		return ResponseEntity.badRequest().body(CommonResponse.fail(

--- a/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
+++ b/event-service/src/main/java/com/fix/event_service/application/exception/EventExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.fix.event_service.application.exception;
 
 import com.fix.common_service.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -11,11 +13,36 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class EventExceptionHandler {
 
 	@ExceptionHandler(exception = {EventException.class})
-	public ResponseEntity<CommonResponse<EventException>> errorResponse(EventException exception) {
-		log.error("[ErrorCode] = {} , [ErrorMessage] = {}", exception.getErrorCode(), exception.getMessage());
+	public ResponseEntity<CommonResponse<EventException>> errorResponse(
+		EventException exception, HttpServletRequest request) {
+		log.error("EventException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(),
+			exception.getErrorCode(), exception.getMessage());
 
 		return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
 			exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
+		));
+	}
+
+	@ExceptionHandler(exception = {IllegalArgumentException.class})
+	public ResponseEntity<CommonResponse<String>> illegalArgumentException(
+		IllegalArgumentException exception, HttpServletRequest request) {
+		log.error("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+		return ResponseEntity.badRequest().body(CommonResponse.fail(
+			"Illegal Argument", exception.getMessage(), HttpStatus.BAD_REQUEST.value()
+		));
+	}
+
+	@ExceptionHandler(exception = {Exception.class})
+	public ResponseEntity<CommonResponse<String>> exception(
+		Exception exception, HttpServletRequest request) {
+		log.error("예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+		return ResponseEntity.internalServerError().body(CommonResponse.fail(
+			"Internal Server Error", exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR.value()
 		));
 	}
 }

--- a/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
@@ -1,5 +1,6 @@
 package com.fix.event_service.presentation.controller;
 
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.common_service.dto.CommonResponse;
 import com.fix.event_service.application.aop.ValidateUser;
 import com.fix.event_service.application.dtos.request.EventCreateRequestDto;
@@ -29,6 +30,7 @@ public class EventController {
     }
 
     // ✅ 이벤트 응모 API
+    @ApiLogging
     @PostMapping("/{eventId}")
     public ResponseEntity<CommonResponse<Void>> applyEvent(
         @PathVariable("eventId") UUID eventId, @RequestHeader("x-user-id") Long userId) {
@@ -64,6 +66,7 @@ public class EventController {
     }
 
     // ✅ 이벤트 검색 API
+    @ApiLogging
     @GetMapping("/search")
     public ResponseEntity<CommonResponse<PageResponseDto<EventResponseDto>>> searchEvents(
             @RequestParam("status") EventStatus status,
@@ -85,6 +88,7 @@ public class EventController {
     }
 
     // ✅ 당첨자 선정 API
+    @ApiLogging
     @ValidateUser(roles = {"MASTER", "MANAGER"})
     @PatchMapping("/{eventId}/announce-winners")
     public ResponseEntity<CommonResponse<WinnerListResponseDto>> announceWinners(@PathVariable("eventId") UUID eventId) {

--- a/event-service/src/main/resources/logback-spring.xml
+++ b/event-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <property name="SERVICE_NAME" value="event-service"/>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp><timeZone>Asia/Seoul</timeZone></timestamp>
+                <version/>
+                <logLevel><fieldName>log.level</fieldName></logLevel>
+                <loggerName><fieldName>log.logger</fieldName></loggerName>
+                <threadName><fieldName>thread.name</fieldName></threadName>
+                <message/>
+                <stackTrace><fieldName>error.stack_trace</fieldName></stackTrace>
+                <mdc/> <pattern>
+                <pattern>
+                    { "service.name": "${SERVICE_NAME}" }
+                </pattern>
+            </pattern>
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId:-NONE}] - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <springProfile name="!dev &amp; !local">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </springProfile>
+        <springProfile name="dev | local">
+            <appender-ref ref="CONSOLE_TEXT"/>
+        </springProfile>
+    </root>
+
+    <logger name="p6spy" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework.kafka" level="WARN"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.fix.event_service" level="INFO"/>
+    <logger name="com.fix.common_service" level="INFO"/>
+
+</configuration>

--- a/event-service/src/main/resources/spy.properties
+++ b/event-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger

--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -51,6 +51,14 @@ dependencies {
 	// ✅ JSON
 	implementation 'org.json:json:20230227'
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/game-service/src/main/java/com/fix/game_service/application/exception/GameExceptionHandler.java
+++ b/game-service/src/main/java/com/fix/game_service/application/exception/GameExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.fix.game_service.application.exception;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -13,12 +14,36 @@ import lombok.extern.slf4j.Slf4j;
 public class GameExceptionHandler {
 
 	@ExceptionHandler(exception = {GameException.class})
-	public ResponseEntity<CommonResponse<GameException>> errorResponse(GameException exception) {
-		log.error("[ErrorCode] = {} , [ErrorMessage] = {}", exception.getErrorCode(), exception.getMessage());
+	public ResponseEntity<CommonResponse<GameException>> errorResponse(
+		GameException exception, HttpServletRequest request) {
+		log.warn("GameException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(),
+			exception.getErrorCode(), exception.getMessage());
 
 		return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
 			exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
 		));
 	}
 
+	@ExceptionHandler(exception = {IllegalArgumentException.class})
+	public ResponseEntity<CommonResponse<String>> illegalArgumentException(
+		IllegalArgumentException exception, HttpServletRequest request) {
+		log.warn("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+		return ResponseEntity.badRequest().body(CommonResponse.fail(
+			"Illegal Argument", exception.getMessage(), 400
+		));
+	}
+
+	@ExceptionHandler(exception = {Exception.class})
+	public ResponseEntity<CommonResponse<String>> exception(
+		Exception exception, HttpServletRequest request) {
+		log.error("예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+		return ResponseEntity.internalServerError().body(CommonResponse.fail(
+			"Internal Server Error", exception.getMessage(), 500
+		));
+	}
 }

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/GameController.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/GameController.java
@@ -2,6 +2,7 @@ package com.fix.game_service.presentation.controller;
 
 import java.util.UUID;
 
+import com.fix.common_service.aop.ApiLogging;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +48,7 @@ public class GameController {
 	 * @param request : 생성할 경기 내용
 	 * @return : 생성한 경기
 	 */
+	@ApiLogging
 	@ValidateUser(roles = {"MASTER", "MANAGER"})
 	@PostMapping
 	public ResponseEntity<CommonResponse<GameCreateResponse>> createGame(

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/QueueController.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/QueueController.java
@@ -1,5 +1,6 @@
 package com.fix.game_service.presentation.controller;
 
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.game_service.application.service.QueueService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,7 @@ public class QueueController {
 
 	private final QueueService queueService;
 
+	@ApiLogging
 	@PostMapping("/{gameId}/enter")
 	public ResponseEntity<Map<String, Object>> enterQueue(@PathVariable UUID gameId, @RequestHeader("x-user-id") Long userId) {
 		Map<String, Object> response = queueService.enterQueue(gameId, userId);

--- a/game-service/src/main/resources/logback-spring.xml
+++ b/game-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <property name="SERVICE_NAME" value="game-service"/>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp><timeZone>Asia/Seoul</timeZone></timestamp>
+                <version/>
+                <logLevel><fieldName>log.level</fieldName></logLevel>
+                <loggerName><fieldName>log.logger</fieldName></loggerName>
+                <threadName><fieldName>thread.name</fieldName></threadName>
+                <message/>
+                <stackTrace><fieldName>error.stack_trace</fieldName></stackTrace>
+                <mdc/> <pattern>
+                <pattern>
+                    { "service.name": "${SERVICE_NAME}" }
+                </pattern>
+            </pattern>
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId:-NONE}] - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <springProfile name="!dev &amp; !local">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </springProfile>
+        <springProfile name="dev | local">
+            <appender-ref ref="CONSOLE_TEXT"/>
+        </springProfile>
+    </root>
+
+    <logger name="p6spy" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework.kafka" level="WARN"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.fix.game_service" level="INFO"/>
+
+</configuration>

--- a/game-service/src/main/resources/spy.properties
+++ b/game-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -49,6 +49,14 @@ dependencies {
 	// ✅ JSON
 	implementation 'org.json:json:20230227'
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/order-service/src/main/java/com/fix/order_service/application/OrderService.java
+++ b/order-service/src/main/java/com/fix/order_service/application/OrderService.java
@@ -110,6 +110,7 @@ public class OrderService {
 
     @Transactional
     public void cancelOrderFromPayment(UUID orderId, String reason) {
+        log.info("[Order] 결제 실패/취소로 인한 주문 취소 시작 - orderId={}, reason={}", orderId, reason);
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new OrderException(OrderException.OrderErrorType.ORDER_NOT_FOUND));
 
@@ -119,7 +120,7 @@ public class OrderService {
         orderProducer.sendOrderCancelledEvent(payload.getOrderId().toString(), payload);
 
         // TicketClient 호출은 제외 (결제 실패로 인해 직접 예약 취소가 이미 됐다고 가정)
-        log.info("💬 [Order] 결제 실패/취소로 인한 주문 상태 변경 완료 - orderId={}, reason={}", orderId, reason);
+        log.info("💬 [Order] 결제 실패/취소로 인한 주문 취소 완료 - orderId={}, reason={}", orderId, reason);
 //        ticketClient.cancelTicketStatus(orderId);
     }
 

--- a/order-service/src/main/java/com/fix/order_service/application/exception/OrderExceptionHandler.java
+++ b/order-service/src/main/java/com/fix/order_service/application/exception/OrderExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.fix.order_service.application.exception;
 
 import com.fix.common_service.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,13 +12,42 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class OrderExceptionHandler {
 
     @ExceptionHandler(OrderException.class)
-    public ResponseEntity<CommonResponse<Void>> handleOrderException(OrderException exception) {
-        log.error("[OrderError] code = {}, message = {}", exception.getErrorCode(), exception.getMessage());
+    public ResponseEntity<CommonResponse<Void>> handleOrderException(
+        OrderException exception, HttpServletRequest request) {
+        log.warn("OrderException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(),
+            exception.getErrorCode(), exception.getMessage());
 
         return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
                 exception.getErrorCode(),
                 exception.getMessage(),
                 exception.getStatus().value()
+        ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponse<Void>> handleIllegalArgumentException(
+        IllegalArgumentException exception, HttpServletRequest request) {
+        log.warn("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.badRequest().body(CommonResponse.fail(
+                "Illegal Argument",
+                exception.getMessage(),
+                400
+        ));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<Void>> handleException(
+        Exception exception, HttpServletRequest request) {
+        log.error("예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.internalServerError().body(CommonResponse.fail(
+                "Internal Server Error",
+                exception.getMessage(),
+                500
         ));
     }
 }

--- a/order-service/src/main/java/com/fix/order_service/presantation/OrderRedisController.java
+++ b/order-service/src/main/java/com/fix/order_service/presantation/OrderRedisController.java
@@ -1,5 +1,6 @@
 package com.fix.order_service.presantation;
 
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.common_service.dto.CommonResponse;
 import com.fix.order_service.application.OrderHistoryRedisService;
 import com.fix.order_service.application.dtos.request.OrderSummaryDto;
@@ -22,6 +23,7 @@ public class OrderRedisController {
      * @param userId 헤더로 전달되는 사용자 ID
      * @return 최근 주문 10건
      */
+    @ApiLogging
     @GetMapping("/history/recent")
     @ValidateUser(roles = {"ROLE_CUSTOMER"})
     public ResponseEntity<CommonResponse<List<OrderSummaryDto>>> getRecentOrders(

--- a/order-service/src/main/resources/logback-spring.xml
+++ b/order-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <property name="SERVICE_NAME" value="order-service"/>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp><timeZone>Asia/Seoul</timeZone></timestamp>
+                <version/>
+                <logLevel><fieldName>log.level</fieldName></logLevel>
+                <loggerName><fieldName>log.logger</fieldName></loggerName>
+                <threadName><fieldName>thread.name</fieldName></threadName>
+                <message/>
+                <stackTrace><fieldName>error.stack_trace</fieldName></stackTrace>
+                <mdc/> <pattern>
+                <pattern>
+                    { "service.name": "${SERVICE_NAME}" }
+                </pattern>
+            </pattern>
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId:-NONE}] - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <springProfile name="!dev &amp; !local">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </springProfile>
+        <springProfile name="dev | local">
+            <appender-ref ref="CONSOLE_TEXT"/>
+        </springProfile>
+    </root>
+
+    <logger name="p6spy" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework.kafka" level="WARN"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.fix.order_service" level="INFO"/>
+
+</configuration>

--- a/order-service/src/main/resources/spy.properties
+++ b/order-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger

--- a/stadium-service/build.gradle
+++ b/stadium-service/build.gradle
@@ -20,6 +20,14 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	implementation 'org.postgresql:postgresql:42.7.2'
 
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"

--- a/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/application/exception/StadiumExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.fix.stadium_service.application.exception;
 
 import com.fix.common_service.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -11,12 +12,25 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class StadiumExceptionHandler {
 
 	@ExceptionHandler(exception = {StadiumException.class})
-	public ResponseEntity<CommonResponse<StadiumException>> errorResponse(StadiumException exception) {
-		log.error("[ErrorCode] = {} , [ErrorMessage] = {}", exception.getErrorCode(), exception.getMessage());
+	public ResponseEntity<CommonResponse<StadiumException>> errorResponse(
+		StadiumException exception, HttpServletRequest request) {
+		log.warn("StadiumException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(),
+			exception.getErrorCode(), exception.getMessage());
 
 		return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
 			exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
 		));
 	}
 
+	@ExceptionHandler(exception = {Exception.class})
+	public ResponseEntity<CommonResponse<String>> exception(
+		Exception exception, HttpServletRequest request) {
+		log.error("예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+			request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+		return ResponseEntity.internalServerError().body(CommonResponse.fail(
+			"Internal Server Error", exception.getMessage(), 500
+		));
+	}
 }

--- a/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
+++ b/stadium-service/src/main/java/com/fix/stadium_service/presentation/controller/StadiumController.java
@@ -1,28 +1,20 @@
 package com.fix.stadium_service.presentation.controller;
 
-import com.fix.stadium_service.application.dtos.response.*;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.fix.common_service.dto.StadiumFeignResponse;
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.common_service.dto.CommonResponse;
+import com.fix.common_service.dto.StadiumFeignResponse;
 import com.fix.stadium_service.application.aop.ValidateUser;
 import com.fix.stadium_service.application.dtos.request.StadiumCreateRequest;
 import com.fix.stadium_service.application.dtos.request.StadiumUpdateRequest;
+import com.fix.stadium_service.application.dtos.response.PageResponseDto;
+import com.fix.stadium_service.application.dtos.response.SeatInfoListResponseDto;
+import com.fix.stadium_service.application.dtos.response.SeatSectionListResponseDto;
+import com.fix.stadium_service.application.dtos.response.StadiumResponseDto;
 import com.fix.stadium_service.application.service.StadiumService;
 import com.fix.stadium_service.domain.model.StadiumName;
-
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 
 @RequiredArgsConstructor
@@ -92,12 +84,14 @@ public class StadiumController {
     }
 
 
+    @ApiLogging
     @GetMapping("/{home-team}/games")
     public ResponseEntity<StadiumFeignResponse> getStadiumInfo(@PathVariable(name = "home-team") String homeTeam) {
         return ResponseEntity.ok(stadiumService.getStadiumInfoByName(homeTeam));
     }
 
 
+    @ApiLogging
     @GetMapping("/feign/{stadiumId}/get-seats-by-section")
     SeatInfoListResponseDto getSeatsBySection(@PathVariable("stadiumId") Long stadiumId,
                                               @RequestParam("section") String section) {

--- a/stadium-service/src/main/resources/logback-spring.xml
+++ b/stadium-service/src/main/resources/logback-spring.xml
@@ -3,7 +3,7 @@
 
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
-    <property name="SERVICE_NAME" value="ticket-service"/>
+    <property name="SERVICE_NAME" value="stadium-service"/>
 
     <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
@@ -48,6 +48,6 @@
     <logger name="org.springframework.security" level="INFO"/>
     <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
     <logger name="org.hibernate" level="WARN"/>
-    <logger name="com.fix.ticket_service" level="INFO"/>
+    <logger name="com.fix.stadium_service" level="INFO"/>
 
 </configuration>

--- a/stadium-service/src/main/resources/spy.properties
+++ b/stadium-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -45,6 +45,14 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/exception/TicketException.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/exception/TicketException.java
@@ -1,0 +1,35 @@
+package com.fix.ticket_service.application.exception;
+
+import com.fix.common_service.exception.CustomException;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class TicketException extends CustomException {
+
+    public TicketException(TicketErrorType errorType) {
+        super(errorType.getCode(), errorType.getMessage(), errorType.getStatus());
+    }
+
+    @Getter
+    public enum TicketErrorType {
+        SEAT_LOCK_ACQUIRE_FAILED("TICKET_001", HttpStatus.BAD_REQUEST, "다른 사용자가 좌석을 선택 중입니다."),
+        SEAT_ALREADY_RESERVED_OR_SOLD("TICKET_002", HttpStatus.BAD_REQUEST, "이미 예약되었거나 판매된 좌석이 포함되어 있습니다."),
+        SEAT_LOCK_INTERRUPTED("TICKET_003", HttpStatus.INTERNAL_SERVER_ERROR, "락을 획득하는 동안 문제가 발생했습니다."),
+        TICKET_NOT_FOUND("TICKET_004", HttpStatus.NOT_FOUND, "티켓을 찾을 수 없습니다."),
+        TICKET_CANNOT_DELETE("TICKET_005", HttpStatus.BAD_REQUEST, "삭제할 수 있는 티켓이 없습니다."),
+        QUEUE_TOKEN_REQUIRED("TICKET_006", HttpStatus.BAD_REQUEST, "큐 토큰이 필요합니다."),
+        QUEUE_TOKEN_INVALID("TICKET_007", HttpStatus.BAD_REQUEST, "큐 토큰이 유효하지 않습니다."),
+        UNAUTHORIZED_ACCESS("TICKET_008", HttpStatus.UNAUTHORIZED, "조회, 수정 권한이 없습니다.");
+
+        private final String code;
+        private final HttpStatus status;
+        private final String message;
+
+        TicketErrorType(String code, HttpStatus status, String message) {
+            this.code = code;
+            this.status = status;
+            this.message = message;
+        }
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/exception/TicketExceptionHandler.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/exception/TicketExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.fix.ticket_service.application.exception;
+
+import com.fix.common_service.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class TicketExceptionHandler {
+
+    @ExceptionHandler(exception = {TicketException.class})
+    public ResponseEntity<CommonResponse<TicketException>> errorResponse(
+        TicketException exception, HttpServletRequest request) {
+        log.warn("TicketException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(),
+            exception.getErrorCode(), exception.getMessage());
+
+        return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
+            exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
+        ));
+    }
+
+    @ExceptionHandler(exception = {IllegalArgumentException.class})
+    public ResponseEntity<CommonResponse<String>> illegalArgumentException(
+        IllegalArgumentException exception, HttpServletRequest request) {
+        log.warn("IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.badRequest().body(CommonResponse.fail(
+            "Illegal Argument", exception.getMessage(), HttpStatus.BAD_REQUEST.value()
+        ));
+    }
+
+    @ExceptionHandler(exception = {Exception.class})
+    public ResponseEntity<CommonResponse<String>> exception(
+        Exception exception, HttpServletRequest request) {
+        log.error("예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+            request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.internalServerError().body(CommonResponse.fail(
+            "Internal Server Error", exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR.value()
+        ));
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/domain/model/Ticket.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/domain/model/Ticket.java
@@ -1,5 +1,6 @@
 package com.fix.ticket_service.domain.model;
 
+import com.fix.ticket_service.application.exception.TicketException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -76,7 +77,7 @@ public class Ticket {
 
     public void validateAuth(Long userId, String userRole) {
         if (!this.userId.equals(userId) && !(userRole.equals("MASTER") || userRole.equals("MANAGER"))) {
-            throw new IllegalArgumentException("조회, 수정 권한이 없습니다.");
+            throw new TicketException(TicketException.TicketErrorType.UNAUTHORIZED_ACCESS);
         }
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
@@ -1,5 +1,6 @@
 package com.fix.ticket_service.presentation.controller;
 
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.common_service.dto.CommonResponse;
 import com.fix.ticket_service.application.aop.ValidateUser;
 import com.fix.ticket_service.application.dtos.request.TicketReserveRequestDto;
@@ -21,6 +22,7 @@ public class TicketController {
     private final TicketApplicationService ticketApplicationService;
 
     // ✅ 티켓 예약 API
+    @ApiLogging
     @PostMapping("/reserve")
     public ResponseEntity<CommonResponse<List<TicketReserveResponseDto>>> reserveTicket(
         @RequestBody TicketReserveRequestDto request,
@@ -64,6 +66,7 @@ public class TicketController {
     }
 
     // ✅ 좌석 뷰 조회 API (동적 뷰 생성)
+    @ApiLogging
     @GetMapping("/seat-view/{gameId}")
     public ResponseEntity<CommonResponse<List<SeatStatusResponseDto>>> getSeatView(
         @PathVariable("gameId") UUID gameId,
@@ -74,6 +77,7 @@ public class TicketController {
     }
 
     // ✅ 주문 생성 및 결제 처리가 완료된 티켓 목록 업데이트 API
+    @ApiLogging
     @PostMapping("/sold")
     public ResponseEntity<CommonResponse<Void>> updateTicketStatus(
         @RequestBody TicketSoldRequestDto requestDto) {
@@ -82,6 +86,7 @@ public class TicketController {
     }
 
     // ✅ 주문이 취소된 티켓(List) 상태 업데이트 API
+    @ApiLogging
     @PostMapping("/cancel/{orderId}")
     public ResponseEntity<CommonResponse<Void>> cancelTicketStatus(
         @PathVariable("orderId") UUID orderId) {

--- a/ticket-service/src/main/resources/logback-spring.xml
+++ b/ticket-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <property name="SERVICE_NAME" value="ticket-service"/>
+
+    <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp><timeZone>Asia/Seoul</timeZone></timestamp>
+                <version/>
+                <logLevel><fieldName>log.level</fieldName></logLevel>
+                <loggerName><fieldName>log.logger</fieldName></loggerName>
+                <threadName><fieldName>thread.name</fieldName></threadName>
+                <message/>
+                <stackTrace><fieldName>error.stack_trace</fieldName></stackTrace>
+                <mdc/> <pattern>
+                <pattern>
+                    { "service.name": "${SERVICE_NAME}" }
+                </pattern>
+            </pattern>
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE_TEXT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId:-NONE}] - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <springProfile name="!dev &amp; !local">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </springProfile>
+        <springProfile name="dev | local">
+            <appender-ref ref="CONSOLE_TEXT"/>
+        </springProfile>
+    </root>
+
+    <logger name="p6spy" level="INFO"/>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework.kafka" level="WARN"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/>
+    <logger name="org.springframework.security" level="INFO"/>
+    <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+    <logger name="com.fix.event_service" level="INFO"/>
+    <logger name="com.fix.common_service" level="INFO"/>
+
+</configuration>

--- a/ticket-service/src/main/resources/spy.properties
+++ b/ticket-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -50,6 +50,14 @@ dependencies {
 	implementation 'org.springframework.kafka:spring-kafka'
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
 
+	// ✅ Logging
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+	implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'p6spy:p6spy:3.9.1'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
@@ -1,0 +1,63 @@
+package com.fix.user_service.application.exception;
+
+import com.fix.common_service.dto.CommonResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final String TRACE_ID = "traceId"; // MDC 키
+
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<CommonResponse<UserException>> handleUserException(
+        UserException exception, HttpServletRequest request) {
+        String traceId = MDC.get(TRACE_ID);
+
+        log.error("[{}] UserException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+                traceId, request.getRequestURI(), request.getMethod(),
+                exception.getErrorCode(), exception.getMessage());
+
+        return ResponseEntity.status(exception.getStatus()).body(CommonResponse.fail(
+                exception.getErrorCode(), exception.getMessage(), exception.getStatus().value()
+        ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<String>> handleValidationException(
+            MethodArgumentNotValidException exception, HttpServletRequest request) {
+        String traceId = MDC.get(TRACE_ID);
+        String errorMessages = exception.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        log.error("[{}] ValidationException 발생 : URI={}, Method={}, ErrorMessages={}",
+                traceId, request.getRequestURI(), request.getMethod(), errorMessages);
+
+        return ResponseEntity.badRequest().body(CommonResponse.fail(
+                "Validation Error", errorMessages, HttpStatus.BAD_REQUEST.value()
+        ));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CommonResponse<String>> handleIllegalArgumentException(
+            IllegalArgumentException exception, HttpServletRequest request) {
+        String traceId = MDC.get(TRACE_ID);
+
+        log.error("[{}] IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+                traceId, request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.badRequest().body(CommonResponse.fail(
+                "Illegal Argument", exception.getMessage(), HttpStatus.BAD_REQUEST.value()
+        ));
+    }
+}

--- a/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
@@ -60,4 +60,18 @@ public class GlobalExceptionHandler {
                 "Illegal Argument", exception.getMessage(), HttpStatus.BAD_REQUEST.value()
         ));
     }
+
+    // 예상하지 못한 Exception 도 로깅
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<String>> handleGeneralException(
+            Exception exception, HttpServletRequest request) {
+        String traceId = MDC.get(TRACE_ID);
+
+        log.error("[{}] 예상하지 못한 Exception 발생 : URI={}, Method={}, ErrorMessage={}",
+                traceId, request.getRequestURI(), request.getMethod(), exception.getMessage());
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(CommonResponse.fail(
+                "Internal Server Error", exception.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR.value()
+        ));
+    }
 }

--- a/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
+++ b/user-service/src/main/java/com/fix/user_service/application/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ public class GlobalExceptionHandler {
         UserException exception, HttpServletRequest request) {
         String traceId = MDC.get(TRACE_ID);
 
-        log.error("[{}] UserException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
+        log.warn("[{}] UserException 발생 : URI={}, Method={}, ErrorCode={}, ErrorMessage={}",
                 traceId, request.getRequestURI(), request.getMethod(),
                 exception.getErrorCode(), exception.getMessage());
 
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
                 .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
                 .collect(Collectors.joining(", "));
 
-        log.error("[{}] ValidationException 발생 : URI={}, Method={}, ErrorMessages={}",
+        log.warn("[{}] ValidationException 발생 : URI={}, Method={}, ErrorMessages={}",
                 traceId, request.getRequestURI(), request.getMethod(), errorMessages);
 
         return ResponseEntity.badRequest().body(CommonResponse.fail(
@@ -53,7 +53,7 @@ public class GlobalExceptionHandler {
             IllegalArgumentException exception, HttpServletRequest request) {
         String traceId = MDC.get(TRACE_ID);
 
-        log.error("[{}] IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
+        log.warn("[{}] IllegalArgumentException 발생 : URI={}, Method={}, ErrorMessage={}",
                 traceId, request.getRequestURI(), request.getMethod(), exception.getMessage());
 
         return ResponseEntity.badRequest().body(CommonResponse.fail(

--- a/user-service/src/main/java/com/fix/user_service/config/WebSecurityConfig.java
+++ b/user-service/src/main/java/com/fix/user_service/config/WebSecurityConfig.java
@@ -28,7 +28,7 @@ public class WebSecurityConfig {
         return http
             .securityMatcher("/**")
             .authorizeHttpRequests((authorize) -> authorize
-                .requestMatchers("/api/v1/auth/sign-in", "/api/v1/users/sign-up", "api/v1/users/feign/**",  "/api/v1/auth/user-info/**").permitAll()
+                .requestMatchers("/api/v1/auth/sign-in","/actuator/prometheus", "/api/v1/users/sign-up", "api/v1/users/feign/**",  "/api/v1/auth/user-info/**").permitAll()
                 .anyRequest().authenticated()
             )
             .csrf((csrf) -> csrf.disable())

--- a/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/EventApplicationConsumer.java
+++ b/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/EventApplicationConsumer.java
@@ -41,7 +41,7 @@ public class EventApplicationConsumer extends AbstractKafkaConsumer<EventApplica
             userService.deductPoints(payload.getUserId(), payload.getPoints());
             log.info("[Kafka] 포인트 차감 성공: userId={}, points={}", payload.getUserId(), payload.getPoints());
         } catch (UserException e) {
-            log.error("[Kafka-SAGA] 포인트 차감 실패: eventId={}, userId={}, points={}, error={}",
+            log.warn("[Kafka-SAGA] 포인트 차감 실패: eventId={}, userId={}, points={}, error={}",
                 payload.getEventId(), payload.getUserId(), payload.getPoints(), e.getMessage());
 
             userProducer.sendPointDeductionFailed(payload.getEventId(), payload.getUserId(), payload.getEventEntryId(),

--- a/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/fix/user_service/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.fix.user_service.presentation.controller;
 
+import com.fix.common_service.aop.ApiLogging;
 import com.fix.common_service.dto.CommonResponse;
 import com.fix.common_service.entity.UserRole;
 import com.fix.user_service.application.dtos.request.UserCreateRequestDto;
@@ -32,6 +33,7 @@ public class UserController {
     private final UserService userService;
 
     // 회원가입 (POST /users)
+    @ApiLogging
     @PostMapping("/sign-up")
     public ResponseEntity<UserDetailResponseDto> createUser(@Valid @RequestBody UserCreateRequestDto requestDto,
                                                             BindingResult bindingResult) {
@@ -51,6 +53,7 @@ public class UserController {
     }
 
     // 사용자 검색 (GET /users/search?keyword=xxx&role=MANAGER&page=0&size=10)
+    @ApiLogging
     @GetMapping("/search")
     public ResponseEntity<CommonResponse<UserListResponseDto>> searchUsers(
         @RequestParam(required = false) String keyword,
@@ -67,6 +70,7 @@ public class UserController {
     }
 
     // 관리자용 고급 검색
+    @ApiLogging
     @GetMapping("/admin/search")
     public ResponseEntity<CommonResponse<UserListResponseDto>> searchUsersByCondition(
         @ModelAttribute UserSearchCondition condition,

--- a/user-service/src/main/resources/logback-spring.xml
+++ b/user-service/src/main/resources/logback-spring.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <include resource="org/springframework/boot/logging/logback/base.xml"/>
+
+    <property name="SERVICE_NAME" value="user-service"/>
+    <property name="LOG_PATH" value="user-service\logs"/> <property name="LOG_FILE_NAME" value="${SERVICE_NAME}"/>
+
+    <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file> <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+        <fileNamePattern>${LOG_PATH}/archived/${LOG_FILE_NAME}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+        <maxFileSize>100MB</maxFileSize>
+        <maxHistory>30</maxHistory>
+        <totalSizeCap>10GB</totalSizeCap>
+    </rollingPolicy>
+
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp> <timeZone>Asia/Seoul</timeZone> </timestamp>
+                <version/> <logLevel> <fieldName>log.level</fieldName> </logLevel>
+                <loggerName> <fieldName>log.logger</fieldName>
+                </loggerName>
+                <threadName> <fieldName>thread.name</fieldName>
+                </threadName>
+                <message/> <stackTrace> <fieldName>error.stack_trace</fieldName>
+            </stackTrace>
+
+                <mdc/>
+
+                <pattern>
+                    <pattern>
+                        {
+                        "service.name": "${SERVICE_NAME}"
+                        }
+                    </pattern>
+                </pattern>
+
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} [%X{traceId:-NONE}] - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO"> <appender-ref ref="FILE_JSON"/> <springProfile name="dev | local">
+        <appender-ref ref="CONSOLE"/>
+    </springProfile>
+        <springProfile name="staging | prod">
+        </springProfile>
+    </root>
+
+    <logger name="org.apache.kafka" level="WARN"/>
+    <logger name="org.springframework.kafka" level="WARN"/>
+    <logger name="com.netflix.discovery" level="WARN"/>
+    <logger name="org.springframework.web" level="INFO"/> <logger name="org.springframework.security" level="INFO"/> <logger name="org.springframework.boot.autoconfigure" level="WARN"/>
+    <logger name="org.hibernate" level="WARN"/>
+
+    <logger name="p6spy" level="INFO"/>
+    <logger name="com.fix.user_service" level="INFO"/>
+
+</configuration>

--- a/user-service/src/main/resources/spy.properties
+++ b/user-service/src/main/resources/spy.properties
@@ -1,0 +1,9 @@
+# spy.properties
+
+driverlist=org.postgresql.Driver
+
+logMessageFormat=com.p6spy.engine.spy.appender.CustomLineFormat
+customLogMessageFormat=executionTime: %(executionTime) ms | category: %(category) | sql: %(sqlSingleLine)
+
+# ??? SLF4j(Logback)? ???? ??
+appender=com.p6spy.engine.spy.appender.Slf4JLogger


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
코드 레벨 로그 구성

---

## 📌 작업 개요
- micrometer + prometheus 의존성 추가 (애플리케이션 매트릭 수집용)
- p6spy 라이브러리 및 설정 추가
- logback 설정
- 예외 핸들러 수정 (warn, error 로그 분리)
- Api 성능 측정 및 디버깅용 AOP 구현
- 각 도메인별 핵심 기능에 INFO 로그 추가

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- p6spy는 DB의 쿼리 로그를 보다 상세하게 기록하기 위한 라이브러리라고 생각하시면 됩니다. 쿼리의 실행 시간이나 category를 포함하여 로그를 남길 수 있습니다.
- 모니터링 관련 의존성, p6spy 의존성이 추가됨에 따라 application.yml에 추가되어야 할 설정들이 생겼습니다. 이 부분은 따로 공유 드리겠습니다.

---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):