### PR TITLE
[FP-196-feat/chatting] 채팅 기능 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,6 @@ subprojects {
     apply plugin: 'io.spring.dependency-management'
 
     dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-web'
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     // ✅ Common
     implementation project(':common-service')
 
+    // ✅ Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
     // ✅ Thymeleaf
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -3,15 +3,27 @@ ext {
 }
 
 dependencies {
+	// ✅ Gateway
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+
+	// ✅ Eureka Client
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator' // 💡 관리를 위해 actuator 추가 권장
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// ✅ Actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	// ✅ JJWT core (claim, parser, token 등), JJWT impl & jackson serializer
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// ✅ Netty
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.109.Final:osx-aarch_64'
+
+	// ✅ WebFlux
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 dependencyManagement {

--- a/gateway-service/src/main/java/com/fix/gateway_service/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/com/fix/gateway_service/config/GatewayConfig.java
@@ -1,94 +1,89 @@
 package com.fix.gateway_service.config;
 
-import com.fix.gateway_service.security.JwtAuthFilter;
-import com.fix.gateway_service.security.JwtUtil;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.JwtException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.GatewayFilterSpec;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.http.server.reactive.ServerHttpResponse;
-import org.springframework.web.server.ServerWebExchange;
 
-import java.util.function.Predicate;
+import com.fix.gateway_service.security.JwtAuthFilter;
+import com.fix.gateway_service.security.WebSocketJwtAuthFilter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Configuration
+@RequiredArgsConstructor
 public class GatewayConfig {
 
-    private final JwtAuthFilter jwtAuthFilter;
+	private final JwtAuthFilter jwtAuthFilter;
+	private final WebSocketJwtAuthFilter webSocketJwtAuthFilter;
 
-    public GatewayConfig(JwtAuthFilter jwtAuthFilter) {
-        this.jwtAuthFilter = jwtAuthFilter;
-    }
+	private static final String[] USER_PATHS = {
+		"/api/v1/users/**",
+		"/api/v1/auth/**"
+	};
 
-    private static final String[] USER_PATHS = {
-        "/api/v1/users/**",
-        "/api/v1/auth/**"
-    };
+	@Bean
+	public RouteLocator routeLocator(RouteLocatorBuilder builder) {
+		return builder.routes()
 
-    @Bean
-    public RouteLocator routeLocator(RouteLocatorBuilder builder) {
-        return builder.routes()
+			.route("user-service", r -> r.path(USER_PATHS)
+				.filters(this::applyFilters)
+				.uri("lb://user-service"))
 
-                .route("user-service", r -> r.path(USER_PATHS)
-                        .filters(this::applyFilters)
-                        .uri("lb://user-service"))
+			.route("order-service", r -> r.path("/api/v1/orders/**")
+				.filters(this::applyFilters)
+				.uri("lb://order-service"))
 
-                .route("order-service", r -> r.path("/api/v1/orders/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://order-service"))
+			.route("ticket-service", r -> r.path("/api/v1/tickets/**")
+				.filters(this::applyFilters)
+				.uri("lb://ticket-service"))
 
-                .route("ticket-service", r -> r.path("/api/v1/tickets/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://ticket-service"))
+			.route("game-service", r -> r.path("/api/v1/games/**")
+				.filters(this::applyFilters)
+				.uri("lb://game-service"))
 
-                .route("game-service", r -> r.path("/api/v1/games/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://game-service"))
+			.route("stadium-service", r -> r.path("/api/v1/stadiums/**")
+				.filters(this::applyFilters)
+				.uri("lb://stadium-service"))
 
-                .route("stadium-service", r -> r.path("/api/v1/stadiums/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://stadium-service"))
+			.route("event-service", r -> r.path("/api/v1/events/**")
+				.filters(this::applyFilters)
+				.uri("lb://event-service"))
 
-                .route("event-service", r -> r.path("/api/v1/events/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://event-service"))
+			.route("alarm-service", r -> r.path("/api/v1/alarms/**")
+				.filters(this::applyFilters)
+				.uri("lb://alarm-service"))
 
-                .route("alarm-service", r -> r.path("/api/v1/alarms/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://alarm-service"))
+			.route("chat-service-http", r -> r.path("/api/v1/chats/**")
+				.filters(this::applyFilters)
+				.uri("lb://chat-service"))
 
-                .route("chat-service", r -> r.path("/api/v1/chats/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://chat-service"))
+			.route("chat-service-ws", r -> r.path("/ws-chat/**")
+				.filters(f -> f.filter(webSocketJwtAuthFilter))
+				.uri("lb:ws://chat-service"))
 
-                .route("payments-service", r -> r.path("/api/v1/payments/**")
-                        .filters(this::applyFilters)
-                        .uri("lb://payments-service"))
+			.route("payments-service", r -> r.path("/api/v1/payments/**")
+				.filters(this::applyFilters)
+				.uri("lb://payments-service"))
 
-                .route("fallback-route", r -> r.path("/fallback")
-                        .uri("no://op"))
-                .route("frontend", r -> r.path("/")
-                        .uri("http://localhost:19100"))
-                .build();
-    }
+			.route("fallback-route", r -> r.path("/fallback")
+				.uri("no://op"))
 
-    /**
-     * 공통 필터(JWT 인증 필터 등) 적용
-     */
-    private GatewayFilterSpec applyFilters(GatewayFilterSpec f) {
-        // GlobalFilter를 직접 GatewayFilter로 캐스팅하는 방식 대신 람다로 위임
-        return f.filter((exchange, chain) -> jwtAuthFilter.filter(exchange, chain));
-    }
+			.route("frontend", r -> r.path("/")
+				.uri("http://localhost:19100"))
 
+			.build();
+	}
+
+	/**
+	 * 공통 필터(JWT 인증 필터 등) 적용
+	 */
+	private GatewayFilterSpec applyFilters(GatewayFilterSpec f) {
+		// GlobalFilter를 직접 GatewayFilter로 캐스팅하는 방식 대신 람다로 위임
+		return f.filter((exchange, chain) -> jwtAuthFilter.filter(exchange, chain));
+	}
 
 }

--- a/gateway-service/src/main/java/com/fix/gateway_service/logging/LoggingFilter.java
+++ b/gateway-service/src/main/java/com/fix/gateway_service/logging/LoggingFilter.java
@@ -1,39 +1,48 @@
 package com.fix.gateway_service.logging;
 
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
+
+import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
 public class LoggingFilter implements GlobalFilter, Ordered {
 
-    @Override
-    public Mono<Void> filter(ServerWebExchange exchange, org.springframework.cloud.gateway.filter.GatewayFilterChain chain) {
-        ServerHttpRequest request = exchange.getRequest();
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange,
+		org.springframework.cloud.gateway.filter.GatewayFilterChain chain) {
+		ServerHttpRequest request = exchange.getRequest();
 
-        log.info("➡️ [Gateway 요청] {} {}", request.getMethod(), request.getURI());
-        log.debug("📝 [요청 헤더] {}", request.getHeaders());
+		// WebSocket 관련 요청 처리
+		String upgradeHeader = exchange.getRequest().getHeaders().getFirst("Upgrade");
+		if ("websocket".equalsIgnoreCase(upgradeHeader)) {
+			log.info("➡️ [WebSocket 요청] {} {}", request.getMethod(), request.getURI());
+			return chain.filter(exchange);
+		}
 
-        // 응답 이후 상태코드 로깅 (doAfterTerminate → doFinally 대체로 더 안정적)
-        return chain.filter(exchange)
-                .doFinally(signalType -> {
-                    ServerHttpResponse response = exchange.getResponse();
-                    if (response.getStatusCode() != null) {
-                        log.info("⬅️ [Gateway 응답] 상태 코드: {}", response.getStatusCode().value());
-                    } else {
-                        log.warn("⬅️ [Gateway 응답] 상태 코드 없음");
-                    }
-                });
-    }
+		log.info("➡️ [Gateway 요청] {} {}", request.getMethod(), request.getURI());
+		log.debug("📝 [요청 헤더] {}", request.getHeaders());
 
-    @Override
-    public int getOrder() {
-        return -1; // 가장 먼저 실행
-    }
+		// 응답 이후 상태코드 로깅 (doAfterTerminate → doFinally 대체로 더 안정적)
+		return chain.filter(exchange)
+			.doFinally(signalType -> {
+				ServerHttpResponse response = exchange.getResponse();
+				if (response.getStatusCode() != null) {
+					log.info("⬅️ [Gateway 응답] 상태 코드: {}", response.getStatusCode().value());
+				} else {
+					log.warn("⬅️ [Gateway 응답] 상태 코드 없음");
+				}
+			});
+	}
+
+	@Override
+	public int getOrder() {
+		return -1; // 가장 먼저 실행
+	}
 }

--- a/gateway-service/src/main/java/com/fix/gateway_service/security/WebSocketJwtAuthFilter.java
+++ b/gateway-service/src/main/java/com/fix/gateway_service/security/WebSocketJwtAuthFilter.java
@@ -1,0 +1,87 @@
+package com.fix.gateway_service.security;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketJwtAuthFilter implements GatewayFilter {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+		ServerHttpRequest request = exchange.getRequest();
+		ServerHttpResponse response = exchange.getResponse();
+
+		String authHeader = request.getHeaders().getFirst(HttpHeaders.AUTHORIZATION);
+
+		if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+			return onError(exchange, "토큰이 없습니다. ");
+		}
+
+		String token = authHeader.substring(7);
+
+		try {
+			Claims claims = jwtUtil.extractClaims(token);
+			Integer userId = claims.get("userId", Integer.class);
+			String userRole = claims.get("role", String.class);
+			log.info("userId : {}, userRole : {}", userId, userRole);
+
+			if (Objects.isNull(userId) || Objects.isNull(userRole)) {
+				return onError(exchange, "토큰이 없습니다");
+			}
+
+			log.info("인증된 사용자 - ID: {}, Role: {}", userId, userRole);
+
+			// 사용자 정보를 헤더에 추가
+			ServerHttpRequest modifiedRequest = request.mutate()
+				.headers(headers -> {
+					headers.set("X-User-Id", userId.toString());
+					headers.set("X-User-Role", userRole);
+				})
+				.build();
+
+			return chain.filter(exchange.mutate().request(modifiedRequest).build())
+				.contextWrite(context -> context.put("userId", userId).put("userRole", userRole));
+
+		} catch (ExpiredJwtException e) {
+			log.warn("JWT 만료: {}", e.getMessage());
+			return onError(exchange, "토큰이 만료되었습니다.");
+		} catch (JwtException | IllegalArgumentException e) {
+			log.warn("JWT 검증 실패");
+			return onError(exchange, "유효하지 않은 토큰입니다.");
+		}
+
+	}
+
+	private Mono<Void> onError(ServerWebExchange exchange, String message) {
+		ServerHttpResponse response = exchange.getResponse();
+		response.setStatusCode(HttpStatus.UNAUTHORIZED);
+		response.getHeaders().add("Content-Type", "application/json");
+
+		byte[] bytes = ("{\"error\": \"" + message + "\"}").getBytes(StandardCharsets.UTF_8);
+		DataBuffer buffer = response.bufferFactory().wrap(bytes);
+
+		return response.writeWith(Mono.just(buffer));
+	}
+
+}


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
ex) feat: 경기장 이름으로 검색 API 구현

- WebSocket 요청도 Gateway를 거칠 수 있도록 필터 추가

---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- WebSocket 요청도 Gateway를 거칠 수 있도록 추가

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트

- Gateway를 거쳐서 들어갈 수 있도록 로직을 수정하다 보니, 루트 모듈의 build.gradle과, gateway의 전반적은 내용이 조금씩 수정되었습니다.
- 특히 각 모듈에서 web 의존성이 없는데 필요하다면 모듈 의존성에 추가해주시면 될 것 같습니다
- 이외에도 추가로 chat 모듈에서 변경사항이 필요하시다면 코멘트로 남겨주시면 확인하겠습니다 !

---

## 🧪 테스트 방법 (선택)
- [X] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스