### PR TITLE
[Fix/kafka] : Kafka 관련 버그 수정

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
@@ -11,7 +11,8 @@ public class KafkaTopicConfig {
 
     // Ticket 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.ticket.reserved}") private String ticketReservedTopic;
-    @Value("${kafka-topics.ticket.updated}") private String ticketUpdatedTopic;
+    @Value("${kafka-topics.ticket.sold}") private String ticketSoldTopic;
+    @Value("${kafka-topics.ticket.cancelled}") private String ticketCancelledTopic;
 
     // Order 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.order.created}") private String orderCreatedTopic;
@@ -47,8 +48,16 @@ public class KafkaTopicConfig {
     }
 
     @Bean
-    public NewTopic ticketUpdated() {
-        return TopicBuilder.name(ticketUpdatedTopic)
+    public NewTopic ticketSold() {
+        return TopicBuilder.name(ticketSoldTopic)
+                .partitions(defaultPartitions)
+                .replicas(defaultReplicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic ticketCancelled() {
+        return TopicBuilder.name(ticketCancelledTopic)
                 .partitions(defaultPartitions)
                 .replicas(defaultReplicas)
                 .build();

--- a/common-service/src/main/java/com/fix/common_service/kafka/consumer/AbstractKafkaConsumer.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/consumer/AbstractKafkaConsumer.java
@@ -17,11 +17,13 @@ public abstract class AbstractKafkaConsumer<T> {
     public void consume(ConsumerRecord<String, EventKafkaMessage<T>> record,
                         @Payload EventKafkaMessage<T> message,
                         Acknowledgment ack) {
+        // 1) Kafka Consumer Group ID 가져오기
+        String groupId = getConsumerGroupId();
 
-        // 1) 멱등성 체크를 위한 고유 키 생성
-        String messageKey = record.topic() + "-" + record.partition() + "-" + record.offset();
+        // 2) 멱등성 체크를 위한 고유 키 생성 (토픽-그룹ID-파티션-오프셋)
+        String messageKey = record.topic() + "-" + groupId + "-" + record.partition() + "-" + record.offset();
 
-        // 2) 멱등성 체크 (이미 처리된 메시지인지 확인)
+        // 3) 멱등성 체크 (이미 처리된 메시지인지 확인)
         if (!idempotencyChecker.isNew(messageKey)) {
             // 이미 처리된 경우, Ack만 하고 로직 종료 (중복 처리 방지)
             if (ack != null) {
@@ -30,14 +32,14 @@ public abstract class AbstractKafkaConsumer<T> {
             return; // 종료
         }
 
-        // 3) 처리 시작 로깅
+        // 4) 처리 시작 로깅
         log.info("[Kafka] 이벤트 수신 시작. Topic: {}, Key: {}, Partition: {}, Offset: {}, EventType: {}, Payload: {}",
             record.topic(), record.key(), record.partition(), record.offset(), message.getEventType(), message.getPayload());
 
-        // 4) 핵심 비즈니스 로직 처리 위임
+        // 5) 핵심 비즈니스 로직 처리 위임
         processPayload(message.getPayload());
 
-        // 5) 성공 시 처리 완료 마킹 및 Ack
+        // 6) 성공 시 처리 완료 마킹 및 Ack
         idempotencyChecker.markProcessed(messageKey); // 성공 시에만 처리 완료 마킹
         if (ack != null) {
             ack.acknowledge();
@@ -49,4 +51,6 @@ public abstract class AbstractKafkaConsumer<T> {
     protected <T> T mapPayload(Object rawPayload, Class<T> clazz) {
         return new ObjectMapper().convertValue(rawPayload, clazz);
     }
+
+    protected abstract String getConsumerGroupId();
 }

--- a/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/consumer/PointDeductionFailedConsumer.java
+++ b/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/consumer/PointDeductionFailedConsumer.java
@@ -37,4 +37,9 @@ public class PointDeductionFailedConsumer extends AbstractKafkaConsumer<PointDed
         log.debug("[Kafka-SAGA] 포인트 차감 실패 이벤트 수신: {}", payload);
         eventApplicationService.cancelEventApply(payload);
     }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return CONSUMER_GROUP_ID;
+    }
 }

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketCancelledConsumer.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketCancelledConsumer.java
@@ -1,0 +1,50 @@
+package com.fix.game_service.presentation.controller;
+
+import com.fix.common_service.kafka.consumer.AbstractKafkaConsumer;
+import com.fix.common_service.kafka.consumer.RedisIdempotencyChecker;
+import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.TicketUpdatedPayload;
+import com.fix.game_service.application.service.ConsumerService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TicketCancelledConsumer extends AbstractKafkaConsumer<TicketUpdatedPayload> {
+
+    private final ConsumerService consumerService;
+
+    public TicketCancelledConsumer(RedisIdempotencyChecker idempotencyChecker,
+                                   ConsumerService consumerService) {
+        super(idempotencyChecker);
+        this.consumerService = consumerService;
+    }
+
+    /**
+     * Kafka에서 메시지 소비를 위한 리스너 메서드 정의
+     *
+     * @param message : 이벤트에서 수신할 데이터
+     */
+    @KafkaListener(topics = "ticket-cancelled-topic", groupId = "game-service-ticket-cancelled-consumer")
+    public void updateGameSeatsByConsumer(ConsumerRecord<String, EventKafkaMessage<TicketUpdatedPayload>> record,
+                                          EventKafkaMessage<TicketUpdatedPayload> message,
+                                          Acknowledgment acknowledgment) {
+        log.info("[Kafka] 티켓 취소 이벤트 수신 : {}", message);
+        super.consume(record, message, acknowledgment);
+    }
+
+    @Override
+    protected void processPayload(Object payload) {
+        TicketUpdatedPayload ticketUpdatedPayload = mapPayload(payload, TicketUpdatedPayload.class);
+
+        consumerService.updateGameSeatsByConsumer(ticketUpdatedPayload);
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "game-service-ticket-cancelled-consumer";
+    }
+}

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketGameConsumer.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketGameConsumer.java
@@ -47,6 +47,11 @@ public class TicketGameConsumer extends AbstractKafkaConsumer<TicketUpdatedPaylo
         consumerService.updateGameSeatsByConsumer(payload);
 
     }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "game-service-group";
+    }
 }
 
 

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketSoldConsumer.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/TicketSoldConsumer.java
@@ -15,12 +15,10 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-public class TicketGameConsumer extends AbstractKafkaConsumer<TicketUpdatedPayload> {
-
+public class TicketSoldConsumer extends AbstractKafkaConsumer<TicketUpdatedPayload> {
     private final ConsumerService consumerService;
 
-
-    public TicketGameConsumer(RedisIdempotencyChecker idempotencyChecker,
+    public TicketSoldConsumer(RedisIdempotencyChecker idempotencyChecker,
                               ConsumerService consumerService) {
         super(idempotencyChecker);
         this.consumerService = consumerService;
@@ -32,11 +30,11 @@ public class TicketGameConsumer extends AbstractKafkaConsumer<TicketUpdatedPaylo
      *
      * @param message : 이벤트에서 수신할 데이터
      */
-    @KafkaListener(topics = "ticket-updated-topic", groupId = "game-service-group")
+    @KafkaListener(topics = "ticket-sold-topic", groupId = "game-service-ticket-sold-consumer")
     public void updateGameSeatsByConsumer(ConsumerRecord<String, EventKafkaMessage<TicketUpdatedPayload>> record,
                                           EventKafkaMessage<TicketUpdatedPayload> message,
                                           Acknowledgment acknowledgment) {
-        log.info("[Kafka] 티켓 이벤트 수신 : {}", message.getEventType());
+        log.info("[Kafka] 티켓 판매 이벤트 수신 : {}", message.getEventType());
         super.consume(record, message, acknowledgment);
     }
 
@@ -45,12 +43,11 @@ public class TicketGameConsumer extends AbstractKafkaConsumer<TicketUpdatedPaylo
         TicketUpdatedPayload payload = mapPayload(rawPayload, TicketUpdatedPayload.class);
 
         consumerService.updateGameSeatsByConsumer(payload);
-
     }
 
     @Override
     protected String getConsumerGroupId() {
-        return "game-service-group";
+        return "game-service-ticket-sold-consumer";
     }
 }
 

--- a/order-service/src/main/java/com/fix/order_service/infrastructure/kafka/OrderConsumer.java
+++ b/order-service/src/main/java/com/fix/order_service/infrastructure/kafka/OrderConsumer.java
@@ -41,7 +41,8 @@ public class OrderConsumer {
     /**
      * Kafka로부터 TICKET_RESERVED 이벤트를 수신합니다.
      */
-    @KafkaListener(topics = "${kafka-topics.ticket.reserved}", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "${kafka-topics.ticket.reserved}", containerFactory = "kafkaListenerContainerFactory",
+            groupId = "order-service-ticket-reserved-consumer")
     public void consumeTicketReserved(
             ConsumerRecord<String, EventKafkaMessage<TicketReservedPayload>> record,
             @Payload EventKafkaMessage<TicketReservedPayload> message,
@@ -114,6 +115,11 @@ public class OrderConsumer {
                 throw e; // 필요 시 생략 가능 (consume 종료 목적이면)
             }
         }
+
+        @Override
+        protected String getConsumerGroupId() {
+            return "order-service-ticket-reserved-consumer";
+        }
     }
 
     /**
@@ -135,6 +141,11 @@ public class OrderConsumer {
                     updated.getGameId(), updated.getQuantity());
 
             // TODO: 재고 상태 업데이트 로직 등 연결 가능
+        }
+
+        @Override
+        protected String getConsumerGroupId() {
+            return null;
         }
     }
 }

--- a/order-service/src/main/java/com/fix/order_service/infrastructure/kafka/OrderPaymentConsumer.java
+++ b/order-service/src/main/java/com/fix/order_service/infrastructure/kafka/OrderPaymentConsumer.java
@@ -36,7 +36,8 @@ public class OrderPaymentConsumer {
         this.cancelledConsumer = new PaymentCancelledConsumer(idempotencyChecker, orderService);
     }
 
-    @KafkaListener(topics = "${kafka-topics.payment.completed}", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "${kafka-topics.payment.completed}", containerFactory = "kafkaListenerContainerFactory",
+            groupId = "order-service-payment-completed-consumer")
     public void consumePaymentCompleted(
             ConsumerRecord<String, EventKafkaMessage<PaymentCompletedPayload>> record,
             @Payload EventKafkaMessage<PaymentCompletedPayload> message,
@@ -45,7 +46,8 @@ public class OrderPaymentConsumer {
         completedConsumer.consume(record, message, ack);
     }
 
-    @KafkaListener(topics = "${kafka-topics.payment.completion-failed}", containerFactory = "kafkaListenerContainerFactory")
+    @KafkaListener(topics = "${kafka-topics.payment.completion-failed}", containerFactory = "kafkaListenerContainerFactory",
+            groupId = "order-service-payment-completion-failed-consumer")
     public void consumeCompletionFailed(
             ConsumerRecord<String, EventKafkaMessage<OrderCompletionFailedPayload>> record,
             @Payload EventKafkaMessage<OrderCompletionFailedPayload> message,
@@ -56,7 +58,8 @@ public class OrderPaymentConsumer {
 
     @KafkaListener(
             topics = "${kafka-topics.payment.cancelled}",
-            containerFactory = "kafkaListenerContainerFactory"
+            containerFactory = "kafkaListenerContainerFactory",
+            groupId = "order-service-payment-cancelled-consumer"
     )
     public void consumePaymentCancelled(
             ConsumerRecord<String, EventKafkaMessage<PaymentCancelledPayload>> record,
@@ -92,6 +95,11 @@ public class OrderPaymentConsumer {
                     (int) payload.getAmount()
             );
         }
+
+        @Override
+        protected String getConsumerGroupId() {
+            return "order-service-payment-completed-consumer";
+        }
     }
 
     /**
@@ -119,6 +127,11 @@ public class OrderPaymentConsumer {
                     payload.getFailureReason()
             );
         }
+
+        @Override
+        protected String getConsumerGroupId() {
+            return "order-service-payment-completion-failed-consumer";
+        }
     }
 
     /**
@@ -144,6 +157,11 @@ public class OrderPaymentConsumer {
                     payload.getOrderId(),
                     "사용자 요청에 의한 결제 취소"
             );
+        }
+
+        @Override
+        protected String getConsumerGroupId() {
+            return "order-service-payment-cancelled-consumer";
         }
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
@@ -1,12 +1,12 @@
 package com.fix.ticket_service.application.service;
 
-import com.fix.ticket_service.application.dtos.request.*;
+import com.fix.ticket_service.application.dtos.request.TicketInfoRequestDto;
+import com.fix.ticket_service.application.dtos.request.TicketReserveRequestDto;
+import com.fix.ticket_service.application.dtos.request.TicketSoldRequestDto;
 import com.fix.ticket_service.application.dtos.response.*;
 import com.fix.ticket_service.domain.model.Ticket;
 import com.fix.ticket_service.domain.model.TicketStatus;
 import com.fix.ticket_service.domain.repository.TicketRepository;
-import com.fix.ticket_service.infrastructure.client.GameClient;
-import com.fix.ticket_service.infrastructure.client.OrderClient;
 import com.fix.ticket_service.infrastructure.client.StadiumClient;
 import com.fix.ticket_service.infrastructure.kafka.producer.TicketProducer;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +33,6 @@ import java.util.stream.Collectors;
 public class TicketApplicationService {
 
     private final TicketRepository ticketRepository;
-    private final OrderClient orderClient;
-    private final GameClient gameClient;
     private final StadiumClient stadiumClient;
     private final RedissonClient redissonClient;
     private final TicketProducer ticketProducer;
@@ -208,7 +206,7 @@ public class TicketApplicationService {
 
         // 3) 티켓 업데이트 이벤트 발행 (경기 서버에 잔여 좌석 차감 요청)
         int quantity = tickets.size();
-        ticketProducer.sendTicketUpdatedEvent(tickets.get(0).getGameId(), -quantity);
+        ticketProducer.sendTicketSoldEvent(tickets.get(0).getGameId(), -quantity);
 
         // 4) Redis 캐시에 SOLD 상태 저장 (TTL = 24시간)
         for (Ticket ticket : tickets) {
@@ -229,7 +227,7 @@ public class TicketApplicationService {
 
         // 3) 티켓 업데이트 이벤트 발행 (경기 서버에 잔여 좌석 증가 요청)
         int quantity = tickets.size();
-        ticketProducer.sendTicketUpdatedEvent(tickets.get(0).getGameId(), quantity);
+        ticketProducer.sendTicketCancelledEvent(tickets.get(0).getGameId(), quantity);
 
         // 4) Redis 캐시에서 해당 좌석 키 삭제
         for (Ticket ticket : tickets) {

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCanceledConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCanceledConsumer.java
@@ -42,6 +42,12 @@ public class OrderCanceledConsumer extends AbstractKafkaConsumer<OrderCancelledP
         } catch (IllegalArgumentException e) {
             // 에러 핸들러에 의한 재시도 처리, 보상 트랜잭션은 구현 X
             log.error("[Kafka] 티켓 취소 상태 업데이트 실패: orderId={}, error={}", orderId, e.getMessage());
+            throw e;
         }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "ticket-service-order-canceled-consumer";
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletedConsumer.java
@@ -43,6 +43,12 @@ public class OrderCompletedConsumer extends AbstractKafkaConsumer<OrderCompleted
             // 결제 및 주문이 완료되었는데 롤백을 하는건 뭔가 이상함..
             log.error("[Kafka] 티켓 판매 상태 업데이트 실패: orderId={}, ticketIds={}, error={}",
                 requestDto.getOrderId(), requestDto.getTicketIds(), e.getMessage());
+            throw e;
         }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "ticket-service-order-completed-consumer";
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletionFailedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletionFailedConsumer.java
@@ -40,6 +40,12 @@ public class OrderCompletionFailedConsumer extends AbstractKafkaConsumer<OrderCo
         } catch (IllegalArgumentException e) {
             // 에러 핸들러에 의한 재시도 처리, 보상 트랜잭션은 구현 X
             log.error("[Kafka] 주문 완료 처리에 실패한 티켓 삭제 실패:  error={}", e.getMessage());
+            throw e;
         }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "ticket-service-order-completion-failed-consumer";
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCreationFailedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCreationFailedConsumer.java
@@ -40,6 +40,12 @@ public class OrderCreationFailedConsumer extends AbstractKafkaConsumer<OrderCrea
         } catch (IllegalArgumentException e) {
             // 에러 핸들러에 의한 재시도 처리, 보상 트랜잭션은 구현 X
             log.error("[Kafka] 주문 생성에 실패한 티켓 삭제 실패:  error={}", e.getMessage());
+            throw e;
         }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "ticket-service-order-creation-failed-consumer";
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/producer/TicketProducer.java
@@ -23,8 +23,10 @@ public class TicketProducer {
 
     @Value("${kafka-topics.ticket.reserved}")
     private String ticketReservedTopic;
-    @Value("${kafka-topics.ticket.updated}")
-    private String ticketUpdatedTopic;
+    @Value("${kafka-topics.ticket.sold}")
+    private String ticketSoldTopic;
+    @Value("${kafka-topics.ticket.cancelled}")
+    private String ticketCancelledTopic;
 
     public void sendTicketReservedEvent(List<Ticket> tickets, Long userId) {
         List<TicketReservedPayload.TicketDetail> ticketDetails = tickets.stream()
@@ -39,13 +41,23 @@ public class TicketProducer {
         kafkaProducerHelper.send(ticketReservedTopic, key, eventMessage);
     }
 
-    public void sendTicketUpdatedEvent(UUID gameId, int quantity) {
+    public void sendTicketSoldEvent(UUID gameId, int quantity) {
         TicketUpdatedPayload payload = new TicketUpdatedPayload(gameId, quantity);
 
-        EventKafkaMessage<TicketUpdatedPayload> eventMessage = new EventKafkaMessage<>("TICKET_UPDATED", payload);
+        EventKafkaMessage<TicketUpdatedPayload> eventMessage = new EventKafkaMessage<>("TICKET_SOLD", payload);
 
         String key = gameId.toString();
 
-        kafkaProducerHelper.send(ticketUpdatedTopic, key, eventMessage);
+        kafkaProducerHelper.send(ticketSoldTopic, key, eventMessage);
+    }
+
+    public void sendTicketCancelledEvent(UUID gameId, int quantity) {
+        TicketUpdatedPayload payload = new TicketUpdatedPayload(gameId, quantity);
+
+        EventKafkaMessage<TicketUpdatedPayload> eventMessage = new EventKafkaMessage<>("TICKET_CANCELLED", payload);
+
+        String key = gameId.toString();
+
+        kafkaProducerHelper.send(ticketCancelledTopic, key, eventMessage);
     }
 }

--- a/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/EventApplicationConsumer.java
+++ b/user-service/src/main/java/com/fix/user_service/infrastructure/kafka/consumer/EventApplicationConsumer.java
@@ -48,4 +48,9 @@ public class EventApplicationConsumer extends AbstractKafkaConsumer<EventApplica
                 payload.getPoints(), e.getErrorCode());
         }
     }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "user-service-event-applied-consumer";
+    }
 }


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
Kafka 관련 버그 수정

---

## 📌 작업 개요
- 멱등성 체크 키에 컨슈머 그룹 ID 포함 (동일 이벤트를 두 개 이상의 서버에서 수신할 때 발생하는 버그 수정)
- Ticket -> Game 이벤트 토픽 두 개로 분리 (티켓 판매, 티켓 취소)

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- Game 쪽 이벤트 컨슈머를 두 개로 분리하게 되면서, 클래스 이름을 조금 수정했습니다.
- 하나였던 토픽이 두 개로 분리되면서, yml에도 해당 토픽 정보가 있어야 합니다.


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):