### PR TITLE
[Fp 275 feat/ticket] Redis Keyspace Notifications : 예약 상태의 티켓 자동 정리

### DIFF
--- a/ticket-service/src/main/java/com/fix/ticket_service/application/service/KeyExpiredListener.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/service/KeyExpiredListener.java
@@ -1,0 +1,34 @@
+package com.fix.ticket_service.application.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KeyExpiredListener implements MessageListener {
+
+    private final TicketApplicationService ticketApplicationService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        if (!expiredKey.startsWith("reservation:")) {
+            return; // 다른 만료 이벤트 무시
+        }
+
+        String idPart = expiredKey.substring("reservation:".length());
+        try {
+            UUID ticketId = UUID.fromString(idPart);
+            ticketApplicationService.handleReservationExpiry(ticketId);
+        } catch (IllegalArgumentException e) {
+            // 잘못된 UUID 포맷 등
+            log.error("expired key 에 잘못된 UUID 형식의 티켓 ID가 입력되었습니다: {}", idPart, e);
+        }
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/config/KeyspaceNotificationConfig.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/config/KeyspaceNotificationConfig.java
@@ -1,0 +1,27 @@
+package com.fix.ticket_service.config;
+
+import com.fix.ticket_service.application.service.KeyExpiredListener;
+import com.fix.ticket_service.application.service.TicketApplicationService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class KeyspaceNotificationConfig {
+    @Bean
+    public RedisMessageListenerContainer redisListenerContainer(
+        RedisConnectionFactory factory,
+        KeyExpiredListener keyExpiredListener ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(factory);
+        container.addMessageListener(keyExpiredListener, new PatternTopic("__keyevent@*__:expired"));
+        return container;
+    }
+
+    @Bean
+    public KeyExpiredListener keyExpiredListener(TicketApplicationService service) {
+        return new KeyExpiredListener(service);
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/config/RedisConfig.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.fix.ticket_service.config;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -63,5 +64,14 @@ public class RedisConfig {
         return RedisCacheManager.builder(RedisCacheWriter.nonLockingRedisCacheWriter(connectionFactory))
             .withCacheConfiguration("seatViewCache", seatViewCacheConfig)
             .build();
+    }
+
+    @PostConstruct
+    public void enableKeyspaceEvents() {
+        // Redis Keyspace Notifications 활성화
+        RedisConnectionFactory factory = redisConnectionFactory();
+        factory.getConnection()
+               .serverCommands()
+               .setConfig("notify-keyspace-events", "Ex");
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
@@ -99,11 +99,4 @@ public class TicketController {
         ticketApplicationService.deleteTicket(ticketId, userId, userRole);
         return ResponseEntity.ok(CommonResponse.success(null, "티켓 삭제 성공"));
     }
-
-    // ✅ 예약 상태인 티켓 일괄 삭제 API (스케쥴링용 API)
-    @DeleteMapping("/delete-reserved")
-    public ResponseEntity<CommonResponse<Void>> deleteReservedTickets() {
-        ticketApplicationService.deleteReservedTickets();
-        return ResponseEntity.ok(CommonResponse.success(null, "예약 상태인 티켓 일괄 삭제 성공"));
-    }
 }


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
Redis Keyspace Notifications : 예약 상태의 티켓 자동 정리

---

## 📌 작업 개요
- Redis Keyspace Notifications 를 활용한 예약 상태 티켓 자동 정리(삭제) 기능 구현 

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 기존에는 단순히 스케쥴러를 통해 3분 간격으로 예약 상태의 티켓을 자동 삭제하도록 구현을 하려고 했으나, 문제점을 인지했습니다.
- 보다 효율적인 자동 정리 방식을 고민하다 Redis Keyspace Notifications를 활용한 방식으로 구현해보았습니다.
- 자세한 내용은 따로 정리해두었으니 참고 바랍니다 (https://www.notion.so/teamsparta/1c92dc3ef51481aa96e0da1ee146b453?p=1df2dc3ef5148066a69ed647fd430ec5&pm=s)

---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):