### PR TITLE
[Fp 278 feat/event] 이벤트 상태 변경 스케줄링 처리, 당첨자 선정 후 알림 이벤트 생성

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
@@ -27,6 +27,7 @@ public class KafkaTopicConfig {
     @Value("${kafka-topics.payment.cancelled}") private String paymentCancelledTopic;
     // Event 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.event.applied}") private String eventAppliedTopic;
+    @Value("${kafka-topics.event.winners-announced}") private String eventWinnersAnnouncedTopic;
 
     // User 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.user.point-deduction-failed}") private String userPointDeductionFailedTopic; // SAGA
@@ -130,6 +131,14 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic eventApplied() {
         return TopicBuilder.name(eventAppliedTopic)
+                .partitions(defaultPartitions)
+                .replicas(defaultReplicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic eventWinnersAnnounced() {
+        return TopicBuilder.name(eventWinnersAnnouncedTopic)
                 .partitions(defaultPartitions)
                 .replicas(defaultReplicas)
                 .build();

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/EventWinnersAnnouncedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/EventWinnersAnnouncedPayload.java
@@ -1,0 +1,18 @@
+package com.fix.common_service.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventWinnersAnnouncedPayload {
+    private UUID eventId;
+    private List<Long> winnerIds;
+}

--- a/event-service/build.gradle
+++ b/event-service/build.gradle
@@ -49,6 +49,10 @@ dependencies {
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'p6spy:p6spy:3.9.1'
 
+	// ✅ Quartz Scheduler
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
+	implementation 'org.quartz-scheduler:quartz'
+
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.1"
 

--- a/event-service/src/main/java/com/fix/event_service/application/service/QuartzSchedulerService.java
+++ b/event-service/src/main/java/com/fix/event_service/application/service/QuartzSchedulerService.java
@@ -1,0 +1,53 @@
+package com.fix.event_service.application.service;
+
+import com.fix.event_service.infrastructure.quartz.EventStatusJob;
+import lombok.RequiredArgsConstructor;
+import org.quartz.*;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class QuartzSchedulerService {
+
+    private final Scheduler scheduler;
+
+    public void scheduleEventJob(UUID eventId, Date fireAt, String action) {
+        // JobName: "eventId-action"
+        String jobName = eventId + "-" + action;
+        JobDetail jobDetail = JobBuilder.newJob(EventStatusJob.class)
+            .withIdentity(jobName, "event-jobs")
+            // JobDataMap에 파라미터 저장
+            .usingJobData(EventStatusJob.KEY_EVENT_ID, eventId.toString())
+            .usingJobData(EventStatusJob.KEY_ACTION, action)
+            .build();
+
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withIdentity(jobName + "-trigger", "event-triggers")
+            .startAt(fireAt)  // 지정된 시각에 한 번만 실행
+            .withSchedule(SimpleScheduleBuilder.simpleSchedule()
+                .withMisfireHandlingInstructionFireNow())
+            .build();
+
+        try {
+            // 이미 등록된 Job 이 있으면 삭제 후 재등록
+            if (scheduler.checkExists(jobDetail.getKey())) {
+                scheduler.deleteJob(jobDetail.getKey());
+            }
+            scheduler.scheduleJob(jobDetail, trigger);
+        } catch (SchedulerException e) {
+            throw new RuntimeException("Quartz 스케쥴 등록 실패", e);
+        }
+    }
+
+    public void removeEventJobs(UUID eventId) {
+        try {
+            scheduler.deleteJob(new JobKey(eventId + "-START", "event-jobs"));
+            scheduler.deleteJob(new JobKey(eventId + "-END", "event-jobs"));
+        } catch (SchedulerException e) {
+            throw new RuntimeException("Quartz 스케쥴 삭제 실패", e);
+        }
+    }
+}

--- a/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/producer/EventProducer.java
+++ b/event-service/src/main/java/com/fix/event_service/infrastructure/kafka/producer/EventProducer.java
@@ -2,12 +2,14 @@ package com.fix.event_service.infrastructure.kafka.producer;
 
 import com.fix.common_service.kafka.dto.EventApplicationRequestedPayload;
 import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.EventWinnersAnnouncedPayload;
 import com.fix.common_service.kafka.producer.KafkaProducerHelper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -20,6 +22,9 @@ public class EventProducer {
     @Value("${kafka-topics.event.applied}")
     private String eventAppliedTopic;
 
+    @Value("${kafka-topics.event.winners-announced}")
+    private String eventWinnersAnnouncedTopic;
+
 
     public void sendEventApplyRequest(UUID eventId, Long userId, Integer requiredPoints, UUID eventEntryId) {
         EventApplicationRequestedPayload payload =
@@ -30,5 +35,16 @@ public class EventProducer {
         String key = userId.toString();
 
         kafkaProducerHelper.send(eventAppliedTopic, key, message);
+    }
+
+    public void sendEventWinnersNotification(UUID eventId, List<Long> winnerIds) {
+        EventWinnersAnnouncedPayload payload =
+            new EventWinnersAnnouncedPayload(eventId, winnerIds);
+        EventKafkaMessage<EventWinnersAnnouncedPayload> message =
+            new EventKafkaMessage<>("EVENT_WINNERS_NOTIFICATION", payload);
+
+        String key = eventId.toString();
+
+        kafkaProducerHelper.send(eventWinnersAnnouncedTopic, key, message);
     }
 }

--- a/event-service/src/main/java/com/fix/event_service/infrastructure/quartz/EventStatusJob.java
+++ b/event-service/src/main/java/com/fix/event_service/infrastructure/quartz/EventStatusJob.java
@@ -1,0 +1,34 @@
+package com.fix.event_service.infrastructure.quartz;
+
+import com.fix.event_service.application.service.EventApplicationService;
+import org.quartz.Job;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class EventStatusJob implements Job {
+
+    public static final String KEY_EVENT_ID = "eventId";
+    public static final String KEY_ACTION = "action";  // "START" or "END"
+
+    @Autowired
+    private EventApplicationService eventApplicationService;
+
+    @Override
+    public void execute(JobExecutionContext context) {
+        JobDataMap data = context.getMergedJobDataMap();
+        UUID eventId = UUID.fromString(data.getString(KEY_EVENT_ID));
+        String action = data.getString(KEY_ACTION);
+
+        // 액션에 따라 이벤트 서비스 메서드 호출
+        if ("START".equals(action)) {
+            eventApplicationService.startEventByScheduler(eventId);
+        } else if ("END".equals(action)) {
+            eventApplicationService.endEventAndAnnounceByScheduler(eventId);
+        }
+    }
+}

--- a/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/fix/event_service/presentation/controller/EventController.java
@@ -87,15 +87,6 @@ public class EventController {
         return ResponseEntity.ok(CommonResponse.success(responseDto, "이벤트 정보 수정 성공"));
     }
 
-    // ✅ 당첨자 선정 API
-    @ApiLogging
-    @ValidateUser(roles = {"MASTER", "MANAGER"})
-    @PatchMapping("/{eventId}/announce-winners")
-    public ResponseEntity<CommonResponse<WinnerListResponseDto>> announceWinners(@PathVariable("eventId") UUID eventId) {
-        WinnerListResponseDto responseDto = eventApplicationService.announceWinners(eventId);
-        return ResponseEntity.ok(CommonResponse.success(responseDto, "당첨자 선정 성공"));
-    }
-
     // ✅ 이벤트 논리적 삭제 API
     @ValidateUser(roles = {"MASTER", "MANAGER"})
     @DeleteMapping("/{eventId}")


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
이벤트 상태 변경 스케줄링 처리, 당첨자 선정 후 알림 이벤트 생성

---

## 📌 작업 개요
- Quartz를 활용한 동적인 스케줄링 처리 구현
- 당첨자 선정 후 알림 이벤트 생성

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 스케줄링 처리 시 생기는 기존의 문제점을 해결하고자 Quartz를 활용하였습니다. (https://www.notion.so/teamsparta/1c92dc3ef51481aa96e0da1ee146b453?p=1e02dc3ef5148007b8bfe1879511ba60&pm=s)
- 당첨자 선정 후, 해당 유저들에게 알림을 보내기 위한 이벤트를 생성(발행)했습니다.


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):