### PR TITLE
[FP-114-feat/gaming] 이벤트 처리 Outbox 테이블 추가

### DIFF
--- a/chat-service/src/main/java/com/fix/chat_service/application/service/ChatService.java
+++ b/chat-service/src/main/java/com/fix/chat_service/application/service/ChatService.java
@@ -1,8 +1,11 @@
 package com.fix.chat_service.application.service;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
+import com.fix.common_service.kafka.dto.GameChatPayload;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PagedModel;
@@ -42,6 +45,23 @@ public class ChatService {
 			.chatCloseDate(request.getGameDate().plusDays(1))
 			.gameStatus(request.getGameStatus())
 			.build();
+
+		ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+		log.info(savedChatRoom.getGameDate().toString());
+	}
+
+	public void createChatRoomByGame(GameChatPayload payload) {
+		log.info("[Kafka Event] 서비스로 요청 들어옴");
+		LocalDateTime time = LocalDateTime.parse(payload.getGameDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm[:ss]"));
+		ChatRoom chatRoom = ChatRoom.builder()
+				.chatRoomId(payload.getGameId())
+				.gameId(payload.getGameId())
+				.gameDate(time)
+				.gameName(payload.getGameName())
+				.chatOpenDate(time.minusMinutes(10))
+				.chatCloseDate(time.plusDays(1))
+				.gameStatus(payload.getGameStatus())
+				.build();
 
 		ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
 		log.info(savedChatRoom.getGameDate().toString());
@@ -136,5 +156,4 @@ public class ChatService {
 		return chatRoomRepository.findById(chatId)
 			.orElseThrow(() -> new ChatException(ChatException.ChatErrorType.CHATROOM_NOT_FOUND));
 	}
-
 }

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/config/ObjectMapperConfig.java
@@ -11,8 +11,8 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 @Configuration
 public class ObjectMapperConfig {
 
-    @Bean
-    public ObjectMapper objectMapper() {
+    @Bean(name = "chatObjectMapper")
+    public ObjectMapper chatObjectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
         objectMapper.registerModule(new AfterburnerModule());

--- a/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomWebSocketHandler.java
+++ b/chat-service/src/main/java/com/fix/chat_service/infrastructure/handler/CustomWebSocketHandler.java
@@ -30,7 +30,7 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
 	private final Map<UUID, List<WebSocketSession>> chatRooms = new ConcurrentHashMap<>();
 	// 채팅 생성
 	private final ChatMessageProducer producer;
-	private final ObjectMapper objectMapper;
+	private final ObjectMapper chatObjectMapper;
 
 	@Value("${kafka-topics.chat.message}")
 	private String chatMessageTopic;
@@ -56,7 +56,7 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
 	@Override
 	protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
 		UUID chatId = getChatId(session);
-		ChatMessageDto chatMessageDto = objectMapper.readValue(message.getPayload(), ChatMessageDto.class);
+		ChatMessageDto chatMessageDto = chatObjectMapper.readValue(message.getPayload(), ChatMessageDto.class);
 		String nickname = (String) session.getAttributes().get("nickname");
 		Long userId = (Long) session.getAttributes().get("userId");
 		chatMessageDto.setMessageType("USER");
@@ -73,7 +73,7 @@ public class CustomWebSocketHandler extends TextWebSocketHandler {
 	 */
 	public void broadcastMessage(UUID chatId, ChatMessageDto message) throws IOException {
 		List<WebSocketSession> sessions = chatRooms.get(chatId);
-		String chatMessage = objectMapper.writeValueAsString(message);
+		String chatMessage = chatObjectMapper.writeValueAsString(message);
 		if (sessions != null) {
 			for (WebSocketSession session : sessions) {
 				if (session.isOpen()) {

--- a/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatGameConsumer.java
+++ b/chat-service/src/main/java/com/fix/chat_service/presenatation/consumer/ChatGameConsumer.java
@@ -1,0 +1,48 @@
+package com.fix.chat_service.presenatation.consumer;
+
+import com.fix.chat_service.application.service.ChatService;
+import com.fix.common_service.kafka.consumer.AbstractKafkaConsumer;
+import com.fix.common_service.kafka.consumer.RedisIdempotencyChecker;
+import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.GameChatPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class ChatGameConsumer extends AbstractKafkaConsumer<GameChatPayload> {
+
+    private final ChatService chatService;
+
+    public ChatGameConsumer(RedisIdempotencyChecker idempotencyChecker, ChatService chatService) {
+        super(idempotencyChecker);
+        this.chatService = chatService;
+    }
+
+    @KafkaListener(topics = "game-chat-topic", groupId = "chat-service-created-consumer")
+    public void listenChatRoom(ConsumerRecord<String, EventKafkaMessage<GameChatPayload>> record,
+                               EventKafkaMessage<GameChatPayload> message,
+                               Acknowledgment acknowledgment) {
+        log.info("[Kafka] 채팅방 생성 이벤트 수신 : {}", message.getEventType());
+        super.consume(record, message, acknowledgment);
+    }
+
+    @Override
+    protected void processPayload(Object payload) {
+        try {
+            GameChatPayload newPayload = mapPayload(payload, GameChatPayload.class);
+            log.info("[Kafka] Chat Mapping : {}", newPayload.getGameName());
+            chatService.createChatRoomByGame(newPayload);
+        } catch (Exception e) {
+            log.error("[Kafka] processPayload 실패. Error: {}", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "chat-service-created-consumer";
+    }
+}

--- a/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
@@ -34,6 +34,7 @@ public class KafkaTopicConfig {
 
     // Game 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.game.created}") private String gameCreatedTopic;
+    @Value("${kafka-topics.game.chat}") private String gameChatTopic;
 
     @Value("${default-topic.partitions}") private int defaultPartitions;
     @Value("${default-topic.replicas}") private int defaultReplicas;
@@ -158,6 +159,14 @@ public class KafkaTopicConfig {
             .partitions(1)
             .replicas(defaultReplicas)
             .build();
+    }
+
+    @Bean
+    public NewTopic gameChatTopic() {
+        return TopicBuilder.name(gameChatTopic)
+                .partitions(1)
+                .replicas(defaultReplicas)
+                .build();
     }
 
 }

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/GameChatPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/GameChatPayload.java
@@ -1,12 +1,11 @@
 package com.fix.common_service.kafka.dto;
 
-import java.time.LocalDateTime;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+
+import java.util.UUID;
 
 @Getter
 @Setter
@@ -14,9 +13,9 @@ import lombok.Setter;
 @AllArgsConstructor
 public class GameChatPayload {
 
-	private UUID gameId;
-	private String gameName;
-	private LocalDateTime gameDate;
-	private String gameStatus;
+    private UUID gameId;
+    private String gameName;
+    private String gameDate;
+    private String gameStatus;
 
 }

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/GameChatPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/GameChatPayload.java
@@ -1,0 +1,22 @@
+package com.fix.common_service.kafka.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameChatPayload {
+
+	private UUID gameId;
+	private String gameName;
+	private LocalDateTime gameDate;
+	private String gameStatus;
+
+}

--- a/game-service/build.gradle
+++ b/game-service/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// ✅ PostgreSQL
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// ✅ MongoDB
+	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 	// ✅ Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'

--- a/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
+++ b/game-service/src/main/java/com/fix/game_service/application/exception/GameException.java
@@ -17,7 +17,8 @@ public class GameException extends CustomException {
 		GAME_NOT_FOUND("GAME_001", HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다"),
 		GAME_ROLE_UNAUTHORIZED("GAME_002", HttpStatus.UNAUTHORIZED, "경기 관련 권한이 없습니다"),
 		GAME_CANNOT_RESERVATION("GAME_003", HttpStatus.BAD_REQUEST, "경기 예매 가능 시간이 아닙니다"),
-		GAME_WAITING_ERROR("GAME_004", HttpStatus.BAD_GATEWAY, "경기 대기열과의 접속이 끊어졌습니다");
+		GAME_WAITING_ERROR("GAME_004", HttpStatus.BAD_GATEWAY, "경기 대기열과의 접속이 끊어졌습니다"),
+		GAME_PARSING_ERROR("GAME_005", HttpStatus.BAD_REQUEST, "JSON 파싱에 오류가 발생했습니다");
 
 		private final String code;
 		private final HttpStatus status;

--- a/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
@@ -3,6 +3,7 @@ package com.fix.game_service.application.service;
 import java.util.UUID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.common_service.kafka.dto.GameChatPayload;
 import com.fix.game_service.domain.model.GameEvent;
 import com.fix.game_service.domain.repository.GameEventRepository;
 import org.springframework.cache.Cache;
@@ -86,11 +87,15 @@ public class GameService {
 		// gameProducer.sendGameInfoToAlarm(alarmPayload);
 
 		// 7. 경기 내용 chat으로 전송
-		ChatCreateRequest requestDto = ChatCreateRequest.builder()
+		/*ChatCreateRequest requestDto = ChatCreateRequest.builder()
 			.gameId(savedGame.getGameId()).gameName(savedGame.getGameName())
-			.gameDate(savedGame.getGameDate()).gameStatus(savedGame.getGameStatus().toString()).build();
-		log.debug("Chat 서비스 채팅방 생성 요청 전송: {}", requestDto);
-		chatClient.createChatRoom(requestDto);
+			.gameDate(savedGame.getGameDate()).gameStatus(savedGame.getGameStatus().toString()).build();*/
+		GameChatPayload chatPayload = new GameChatPayload(
+				savedGame.getGameId(), savedGame.getGameName(),
+				savedGame.getGameDate().toString(), savedGame.getGameStatus().toString());
+		log.debug("Chat 서비스 채팅방 생성 요청 전송: {}", chatPayload);
+		// chatClient.createChatRoom(requestDto);
+		gameProducer.sendGameInfoToChat(chatPayload);
 		log.info("Chat 서비스 채팅방 생성 요청 완료: gameId={}", savedGame.getGameId());
 
 		// 8. 경기 내용 반환

--- a/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
@@ -95,7 +95,8 @@ public class GameService {
 				savedGame.getGameDate().toString(), savedGame.getGameStatus().toString());
 		log.debug("Chat 서비스 채팅방 생성 요청 전송: {}", chatPayload);
 		// chatClient.createChatRoom(requestDto);
-		gameProducer.sendGameInfoToChat(chatPayload);
+		// gameProducer.sendGameInfoToChat(chatPayload);
+		saveGameChatEvent(chatPayload);
 		log.info("Chat 서비스 채팅방 생성 요청 완료: gameId={}", savedGame.getGameId());
 
 		// 8. 경기 내용 반환
@@ -103,12 +104,29 @@ public class GameService {
 		return GameCreateResponse.fromGame(savedGame);
 	}
 
+	private void saveGameChatEvent(GameChatPayload chatPayload) {
+		try {
+			String payload = objectMapper.writeValueAsString(chatPayload);
+
+			GameEvent gameEvent = GameEvent.builder()
+					.eventType("GAME_CHAT_CREATED")
+					.aggregateId(chatPayload.getGameId().toString())
+					.payload(payload)
+					.status("PENDING")
+					.build();
+
+			gameEventRepository.save(gameEvent);
+		} catch (Exception e) {
+			throw new GameException(GameException.GameErrorType.GAME_PARSING_ERROR);
+		}
+	}
+
 	private void saveGameAlarmEvent(GameCreatedInfoPayload alarmPayload) {
 		try {
 			String payload = objectMapper.writeValueAsString(alarmPayload);
 
 			GameEvent gameEvent = GameEvent.builder()
-					.eventType("GAME_CREATED")
+					.eventType("GAME_ALARM_CREATED")
 					.aggregateId(alarmPayload.getGameId().toString())
 					.payload(payload)
 					.status("PENDING")

--- a/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
@@ -50,6 +50,7 @@ public class GameService {
 	 * @param request : 생성할 경기 내용
 	 * @return : 반환
 	 */
+	@Transactional
 	public GameCreateResponse createGame(GameCreateRequest request) {
 		log.info("경기 생성 시작: {}", request);
 		// 1. Stadium 쪽으로 요청을 전송하여, homeTeam의 경기장 정보를 받아옴
@@ -67,10 +68,11 @@ public class GameService {
 			savedGame.getGameId(), savedGame.getGameName(), savedGame.getGameDate());
 
 		// 4. 경기 예매 기록 Entity 생성
-		GameRate gameRate = GameRate.builder().gameRateId(savedGame.getGameId()).totalSeats(responseDto.getSeatQuantity()).build();
+		GameRate gameRate = GameRate.builder().totalSeats(responseDto.getSeatQuantity()).build();
 
 		// 5. 생성한 경기 예매 기록 Entity 저장
 		gameRateRepository.save(gameRate);
+		savedGame.updateGameRate(gameRate);
 
 		// 6. 경기 내용 chat으로 전송
 		ChatCreateRequest requestDto = ChatCreateRequest.builder()

--- a/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/GameService.java
@@ -104,7 +104,7 @@ public class GameService {
 
 			GameEvent gameEvent = GameEvent.builder()
 					.eventType("GAME_CREATED")
-					.aggregateId(alarmPayload.getGameId())
+					.aggregateId(alarmPayload.getGameId().toString())
 					.payload(payload)
 					.status("PENDING")
 					.build();

--- a/game-service/src/main/java/com/fix/game_service/application/service/QueueService.java
+++ b/game-service/src/main/java/com/fix/game_service/application/service/QueueService.java
@@ -37,6 +37,12 @@ public class QueueService {
 	private final String WORKING_QUEUE_KEY_PREFIX = "queue:working:";
 	private final String ACTIVE_GAMES_KEY = "active-game";
 
+	/**
+	 * 대기열 입장
+	 * @param gameId : 입장할 경기 ID
+	 * @param userId : 입장 요청한 사용자 ID
+	 * @return : 토큰 반환
+	 */
 	public Map<String, Object> enterQueue(UUID gameId, Long userId) {
 		log.info("대기열 진입 시도: gameId={}, userId={}", gameId, userId);
 		// 1. 해당 경기를 찾아서 예매 가능 시간인지 확인
@@ -156,6 +162,16 @@ public class QueueService {
 	}
 
 	/**
+	 * 작업열로 이동한 토큰을 대기열에서 제거
+	 * @param gameId : 경기 ID
+	 * @param tokens : 제거할 토큰들
+	 */
+	public void deleteTokensFromQueue(UUID gameId, Set<String> tokens) {
+		String queueKey = QUEUE_KEY_PREFIX + gameId;
+		redisTemplate.opsForZSet().remove(queueKey, tokens.toArray());
+	}
+
+	/**
 	 * 외부 요청에 의해 대기열을 떠나는 경우
 	 * @param gameId : 경기 ID
 	 * @param userId : 떠나는 사용자 ID
@@ -169,9 +185,8 @@ public class QueueService {
 
 	/**
 	 * 해당 사용자가 작업 대기열에 존재하는지 확인
-	 *
 	 * @param gameId : 작업 대기열에 있는지 확인할 경기 ID
-	 * @param userId
+	 * @param userId : 사용자 ID
 	 * @param token  : 확인할 토큰
 	 * @return : 토큰 존재 여부 반환
 	 */

--- a/game-service/src/main/java/com/fix/game_service/domain/model/Game.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/model/Game.java
@@ -6,13 +6,16 @@ import java.util.UUID;
 
 import com.fix.common_service.entity.Basic;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.AllArgsConstructor;
@@ -62,6 +65,9 @@ public class Game extends Basic {
 	@Column(nullable = false)
 	private LocalDateTime closeDate;
 
+	@OneToOne(mappedBy = "game", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+	private GameRate gameRate;
+
 	/**
 	 * 경기 내용 수정
 	 * @param updateGameInfo : 수정할 경기 내용
@@ -86,4 +92,11 @@ public class Game extends Basic {
 		Optional.ofNullable(updateGameStatusInfo.getGameStatus()).ifPresent(gameStatus -> this.gameStatus = gameStatus);
 	}
 
+	/**
+	 * 경기 기록 수정
+	 * @param gameRate : 경기 기록
+	 */
+	public void updateGameRate(GameRate gameRate) {
+		this.gameRate = gameRate;
+	}
 }

--- a/game-service/src/main/java/com/fix/game_service/domain/model/GameEvent.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/model/GameEvent.java
@@ -1,0 +1,34 @@
+package com.fix.game_service.domain.model;
+
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Builder
+@Document(collection = "outbox_game_event")
+@NoArgsConstructor
+@AllArgsConstructor
+public class GameEvent {
+
+    @Id
+    private String id;
+
+    private String eventType;
+
+    private UUID aggregateId;
+
+    private String payload;
+
+    private String status;
+
+    private Instant createdAt = Instant.now();
+
+    public void changeStatus(String status) {
+        this.status = status;
+    }
+
+}

--- a/game-service/src/main/java/com/fix/game_service/domain/model/GameEvent.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/model/GameEvent.java
@@ -19,7 +19,7 @@ public class GameEvent {
 
     private String eventType;
 
-    private UUID aggregateId;
+    private String aggregateId;
 
     private String payload;
 
@@ -31,4 +31,7 @@ public class GameEvent {
         this.status = status;
     }
 
+    public void markAsCompleted() {
+        this.status = "COMPLETED";
+    }
 }

--- a/game-service/src/main/java/com/fix/game_service/domain/model/GameRate.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/model/GameRate.java
@@ -4,7 +4,12 @@ import java.util.UUID;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -21,6 +26,7 @@ import lombok.NoArgsConstructor;
 public class GameRate {
 
 	@Id
+	@GeneratedValue(strategy = GenerationType.UUID)
 	private UUID gameRateId;
 
 	@Column
@@ -31,6 +37,10 @@ public class GameRate {
 
 	@Column(nullable = false)
 	private Integer totalSeats;         // 총 좌석
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "game_id")
+	private Game game;
 
 	/**
 	 * 경기 잔여 좌석 및 예매율 수정

--- a/game-service/src/main/java/com/fix/game_service/domain/repository/GameEventRepository.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/repository/GameEventRepository.java
@@ -1,0 +1,7 @@
+package com.fix.game_service.domain.repository;
+
+import com.fix.game_service.domain.model.GameEvent;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface GameEventRepository extends MongoRepository<GameEvent, String> {
+}

--- a/game-service/src/main/java/com/fix/game_service/domain/repository/GameEventRepository.java
+++ b/game-service/src/main/java/com/fix/game_service/domain/repository/GameEventRepository.java
@@ -3,5 +3,8 @@ package com.fix.game_service.domain.repository;
 import com.fix.game_service.domain.model.GameEvent;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
+import java.util.List;
+
 public interface GameEventRepository extends MongoRepository<GameEvent, String> {
+    List<GameEvent> findByStatus(String pending);
 }

--- a/game-service/src/main/java/com/fix/game_service/presentation/controller/GameProducer.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/controller/GameProducer.java
@@ -1,29 +1,37 @@
 package com.fix.game_service.presentation.controller;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
-
 import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.GameChatPayload;
 import com.fix.common_service.kafka.dto.GameCreatedInfoPayload;
 import com.fix.common_service.kafka.producer.KafkaProducerHelper;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GameProducer {
 
-	private final KafkaProducerHelper kafkaProducerHelper;
+    private final KafkaProducerHelper kafkaProducerHelper;
 
-	@Value("${kafka-topics.game.created}")
-	private String gameAlarmTopic;
+    @Value("${kafka-topics.game.created}")
+    private String gameAlarmTopic;
 
-	public void sendGameInfoToAlarm(GameCreatedInfoPayload payload) {
-		EventKafkaMessage<GameCreatedInfoPayload> eventKafkaMessage = new EventKafkaMessage<>("GAME_CREATED", payload);
+    @Value("${kafka-topics.game.chat}")
+    private String gameChatTopic;
 
-		kafkaProducerHelper.send(gameAlarmTopic, payload.getGameId().toString(), eventKafkaMessage);
-	}
+    public void sendGameInfoToAlarm(GameCreatedInfoPayload payload) {
+        EventKafkaMessage<GameCreatedInfoPayload> eventKafkaMessage = new EventKafkaMessage<>("GAME_CREATED", payload);
+
+        kafkaProducerHelper.send(gameAlarmTopic, payload.getGameId().toString(), eventKafkaMessage);
+    }
+
+    public void sendGameInfoToChat(GameChatPayload payload) {
+        EventKafkaMessage<GameChatPayload> eventKafkaMessage = new EventKafkaMessage<>("GAME_CHAT_CREATED", payload);
+
+        kafkaProducerHelper.send(gameChatTopic, payload.getGameId().toString(), eventKafkaMessage);
+    }
 
 }

--- a/game-service/src/main/java/com/fix/game_service/presentation/scheduler/GameEventScheduler.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/scheduler/GameEventScheduler.java
@@ -1,0 +1,55 @@
+package com.fix.game_service.presentation.scheduler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fix.common_service.kafka.dto.GameCreatedInfoPayload;
+import com.fix.game_service.application.exception.GameException;
+import com.fix.game_service.domain.model.GameEvent;
+import com.fix.game_service.domain.repository.GameEventRepository;
+import com.fix.game_service.presentation.controller.GameProducer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GameEventScheduler {
+
+    private final GameEventRepository gameEventRepository;
+    private final GameProducer gameProducer;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(fixedDelay = 3000)
+    public void processGameEventOutbox() {
+        List<GameEvent> pendingGameEvents = gameEventRepository.findByStatus("PENDING");
+
+        for (GameEvent event : pendingGameEvents) {
+            try {
+                GameCreatedInfoPayload payload = convertPayload(event.getEventType(), event.getPayload());
+                gameProducer.sendGameInfoToAlarm(payload);
+
+                // 성공하면 상태 변경
+                event.markAsCompleted();
+                gameEventRepository.save(event);
+
+                log.info("Outbox 이벤트 발송 완료: {}", event.getId());
+            } catch (Exception e) {
+                log.error("Outbox 이벤트 발송 실패: {}", event.getId(), e);
+                throw new GameException(GameException.GameErrorType.GAME_PARSING_ERROR);
+            }
+        }
+    }
+
+    private GameCreatedInfoPayload convertPayload(String eventType, String payload) throws Exception {
+        switch (eventType) {
+            case "GAME_CREATED":
+                return objectMapper.readValue(payload, GameCreatedInfoPayload.class);
+            default:
+                throw new IllegalArgumentException("Unknown eventType: " + eventType);
+        }
+    }
+
+}

--- a/game-service/src/main/java/com/fix/game_service/presentation/scheduler/QueueScheduler.java
+++ b/game-service/src/main/java/com/fix/game_service/presentation/scheduler/QueueScheduler.java
@@ -1,8 +1,10 @@
 package com.fix.game_service.presentation.scheduler;
 
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -27,7 +29,7 @@ public class QueueScheduler {
 	// 한 번에 넘길 사용자 수
 	private final int BATCH_SIZE = 10;
 
-	@Scheduled(initialDelay = 5000, fixedRate = 3000)
+	@Scheduled(initialDelay = 5000, fixedDelay = 3000)
 	public void processQueueLogic() {
 		// 현재 예매 중인 경기 데이터 검색
 		Set<String> gameIdObjects = redisTemplate.opsForSet().members(ACTIVE_GAMES_KEY);
@@ -45,17 +47,19 @@ public class QueueScheduler {
 			Map<Object, Object> gameInfo = redisTemplate.opsForHash().entries(infoKey);
 			if (gameInfo.isEmpty()) continue;
 
-			// 정상 처리: 대기열 → 작업열
-			Set<String> tokens = queueService.getRemainUsersInQueue(gameId, BATCH_SIZE);
-			// 대기열에서 작업열로 사용자 이동
-			if (tokens == null || tokens.isEmpty()) {
-				continue;
-			}
-			sendToNextQueue(gameId, tokens);
-
-			// 대기열 전체 사용자에게 대기번호 전송
 			Set<String> allTokens = queueService.getAllTokensInQueue(gameId);
-			sendWaitingNumber(gameId, allTokens);
+			if (allTokens != null && !allTokens.isEmpty()) {
+				// 대기열 → 작업열
+				Set<String> batchTokens = new HashSet<>(allTokens.stream().limit(BATCH_SIZE).collect(Collectors.toList()));
+				sendToNextQueue(gameId, batchTokens);
+
+				// 이외 토큰을 소유한 사용자에게 대기번호 전송
+				Set<String> remainingTokens = allTokens.stream().skip(BATCH_SIZE).collect(Collectors.toSet());
+				sendWaitingNumber(gameId, remainingTokens);
+
+				// 작업열로 이동한 토큰 한 번에 삭제
+				queueService.deleteTokensFromQueue(gameId, batchTokens);
+			}
 		}
 	}
 
@@ -69,7 +73,6 @@ public class QueueScheduler {
 			log.info("다음 작업열로 이동할 Token: {}", token);
 			try {
 				queueService.moveToWorkingQueue(gameId, token);
-				queueService.leaveQueue(gameId, token);
 			} catch (Exception e) {
 				log.error("입장 처리 실패 [{}]: {}", token, e.getMessage());
 			}

--- a/gateway-service/src/main/java/com/fix/gateway_service/config/GatewayConfig.java
+++ b/gateway-service/src/main/java/com/fix/gateway_service/config/GatewayConfig.java
@@ -41,9 +41,13 @@ public class GatewayConfig {
 				.filters(this::applyFilters)
 				.uri("lb://ticket-service"))
 
-			.route("game-service", r -> r.path("/api/v1/games/**")
+			.route("game-service-http", r -> r.path("/api/v1/games/**")
 				.filters(this::applyFilters)
 				.uri("lb://game-service"))
+
+			.route("game-service-ws", r -> r.path("/ticketing/**")
+				.filters(f -> f.filter(webSocketJwtAuthFilter))
+				.uri("lb:ws://game-service"))
 
 			.route("stadium-service", r -> r.path("/api/v1/stadiums/**")
 				.filters(this::applyFilters)


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
ex) feat: 경기장 이름으로 검색 API 구현

- Game에서 전송하는 이벤트 Repository 생성
- Outbox 전송 스케줄러 구현

---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

- Alarm과 Chat으로 전송할 이벤트 Repository 생성
- 기존 Game - Chat 전송을 Feign에서 Kafka로 수정

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 로직을 같이 건드리다 보니, Chat 브랜치로 넘어가서 작업하지 않고 한 번에 Game 에서 작업하게 되었습니다
- Alarm과 Chat으로 전송하는 이벤트 2개에 대해 Event Repository + Scheduled 로 구현해봤습니다
   - 추후 스케줄링 부분은 Quartz로 전환할 될 예정입니다 
   - 간단하게 Outbox Pattern 이 적용되었다고 생각해주셔도 좋을 것 같은데, 개선하면서 outbox pattern 데이터 처리도 더 추가해볼 예정입니다

---

## 🧪 테스트 방법 (선택)
- [X] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스