### PR TITLE
[FP-296] feat : order 가 발행한 서비스 구독 및 경기 예매자에게 알람 발신

### DIFF
--- a/alarm-service/src/main/java/com/fix/alarm_service/application/service/AlarmService.java
+++ b/alarm-service/src/main/java/com/fix/alarm_service/application/service/AlarmService.java
@@ -30,10 +30,8 @@ public class AlarmService {
     private final SnsClient snsClient;
 
 
-
-
-    @Scheduled(cron = "0/30 * * * * *") //매일 00:00:00 에 한번 실행
-    public void publishGamesAlarmStartingTomorrow(){
+    @Scheduled(cron = "0 0 0 * * *") //매일 00:00:00 에 한번 실행
+    public void publishGamesAlarmStartingTomorrow() {
 
         // 현재 시간 기준
         LocalDateTime now = LocalDateTime.now();
@@ -41,34 +39,29 @@ public class AlarmService {
         LocalDateTime to = now.plusDays(1).withHour(23).withMinute(59).withSecond(59);
         List<GameAlarmSchedule> schedules = scheduleRepository.findByGameDateBetweenAndIsSentFalse(from, to);
 
-        if(schedules.isEmpty()){
+        if (schedules.isEmpty()) {
             log.info("[Scheduler] 내일 경기 없음. 이벤트 발행 스킵");
             return;
         }
 
-        for(GameAlarmSchedule schedule : schedules){
+        for (GameAlarmSchedule schedule : schedules) {
             alarmProducer.sendGameIdToOrder(schedule.getGameId());
             schedule.markAsSent(); // 발행했으니 sent = true
-            log.info("[scheduler] 경기 알림 발행 완료 - gameId:{}",schedule.getGameId());
+            log.info("[scheduler] 경기 알림 발행 완료 - gameId:{}", schedule.getGameId());
 
         }
         scheduleRepository.saveAll(schedules);
     }
 
 
-
-
-
-
-    public PhoneNumberResponseDto getPhoneNumber(Long userId){
+    public PhoneNumberResponseDto getPhoneNumber(Long userId) {
         return userClient.getPhoneNumber(userId);
     }
 
 
+    public String sendSns(String rawPhoneNumber, String message) {
 
-    public String sendSns(String rawPhoneNumber, String message){
-
-        try{
+        try {
             String formattedPhoneNumber = formatPhoneNumber(rawPhoneNumber);
 
             PublishRequest request = PublishRequest.builder()
@@ -80,7 +73,7 @@ public class AlarmService {
 
             log.info("SNS 발송 성공: {}", response.messageId());
             return response.messageId();
-        } catch (SnsException e){
+        } catch (SnsException e) {
             log.error("SNS 발송 실패 : {}", e.awsErrorDetails().errorMessage());
             throw new RuntimeException("SNS 발송 중 오류가 발생했습니다.");
 
@@ -88,25 +81,22 @@ public class AlarmService {
     }
 
     @Transactional
-    public void saveSchedule(GameAlarmSchedule schedule){
+    public void saveSchedule(GameAlarmSchedule schedule) {
         scheduleRepository.save(schedule);
     }
 
 
 
-
-    private String formatPhoneNumber(String rawPhoneNumber){
-        if(rawPhoneNumber == null || rawPhoneNumber.isBlank()){
-            throw new IllegalArgumentException("전화번호가 유효하지 않습니다") ;//TODO 공통 예외처리하기
+    private String formatPhoneNumber(String rawPhoneNumber) {
+        if (rawPhoneNumber == null || rawPhoneNumber.isBlank()) {
+            throw new IllegalArgumentException("전화번호가 유효하지 않습니다");//TODO 공통 예외처리하기
 
         }
         return rawPhoneNumber.startsWith("0")
-                ? "+82" +rawPhoneNumber.substring(1)
+                ? "+82" + rawPhoneNumber.substring(1)
                 : rawPhoneNumber;
 
     }
-
-
 
 
 }

--- a/alarm-service/src/main/java/com/fix/alarm_service/infrastructure/kafka/consumer/OrderSendAlarmUserIdsConsumer.java
+++ b/alarm-service/src/main/java/com/fix/alarm_service/infrastructure/kafka/consumer/OrderSendAlarmUserIdsConsumer.java
@@ -1,0 +1,71 @@
+package com.fix.alarm_service.infrastructure.kafka.consumer;
+
+import com.fix.alarm_service.application.dtos.response.PhoneNumberResponseDto;
+import com.fix.alarm_service.application.service.AlarmService;
+import com.fix.common_service.kafka.consumer.AbstractKafkaConsumer;
+import com.fix.common_service.kafka.consumer.RedisIdempotencyChecker;
+import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.OrderSendAlarmUserIdsPayload;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Optional;
+
+
+@Slf4j
+@Component
+public class OrderSendAlarmUserIdsConsumer extends AbstractKafkaConsumer<OrderSendAlarmUserIdsPayload> {
+
+    private final AlarmService alarmService;
+
+
+    public OrderSendAlarmUserIdsConsumer(RedisIdempotencyChecker idempotencyChecker, AlarmService alarmService) {
+        super(idempotencyChecker);
+        this.alarmService = alarmService;
+    }
+
+    @KafkaListener(
+            topics = "${kafka-topics.order.send-alarm-userIds}",
+            groupId = "alarm-service-order-send-alarm-userIds-consumer"
+    )
+
+    public void listen(ConsumerRecord<String, EventKafkaMessage<OrderSendAlarmUserIdsPayload>> record,
+                       EventKafkaMessage<OrderSendAlarmUserIdsPayload> message,
+                       Acknowledgment ack) {
+        super.consume(record, message, ack);
+    }
+
+
+    @Override
+    protected void processPayload(Object rawPayload) {
+
+        OrderSendAlarmUserIdsPayload payload = mapPayload(rawPayload,  OrderSendAlarmUserIdsPayload.class);
+        Optional.ofNullable(payload.getUserIds())
+                .orElse(Collections.emptyList())
+                .forEach(userId -> {
+                    try {
+                        PhoneNumberResponseDto phone = alarmService.getPhoneNumber(userId);
+                        String message = String.format(
+                                "[경기 알림] 내일은 예약하신 %s 경기가 열립니다.",
+                                payload.getGameId().toString()
+                        );
+                        alarmService.sendSns(phone.getPhoneNumber(), message);
+                        log.info("[Kafka][Alarm] 수신자 {} 에게 당첨 알림 전송 성공", userId);
+                    } catch (Exception e) {
+                        log.error("[Kafka][Alarm] 수신자 {} 에게 당첨 알림 전송 실패 :{}", userId, e.getMessage());
+                    }
+                });
+
+
+
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return "alarm-service-order-send-alarm-userIds-consumer";
+    }
+}


### PR DESCRIPTION
## 🚀 [FP-296] feat : order 가 발행한 서비스 구독 및 경기 예매자에게 알람 발신


---

## 📌 작업 개요
- 어떤 기능을 추가/수정/삭제했는지 간단 요약

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 주요 변경 코드 요약
> 핵심적인 로직이 담긴 클래스/메서드/쿼리 등 설명


- `StadiumService.java`  stadiumName으로 검색하는 메서드 추가 


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):

```http
GET /stadiums/search?name=JAMSIL

[FP-296]: https://dbp100402.atlassian.net/browse/FP-296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ