### PR TITLE
[Fp 275 feat/ticket] Kafka 기반 비동기 병렬 처리를 통한 티켓 예매 처리량 개선

### DIFF
--- a/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/config/KafkaTopicConfig.java
@@ -13,6 +13,9 @@ public class KafkaTopicConfig {
     @Value("${kafka-topics.ticket.reserved}") private String ticketReservedTopic;
     @Value("${kafka-topics.ticket.sold}") private String ticketSoldTopic;
     @Value("${kafka-topics.ticket.cancelled}") private String ticketCancelledTopic;
+    @Value("${kafka-topics.ticket.reservation.request}") private String ticketReservationRequestTopic;
+    @Value("${kafka-topics.ticket.reservation.succeeded}") private String ticketReservationSucceededTopic;
+    @Value("${kafka-topics.ticket.reservation.failed}") private String ticketReservationFailedTopic;
 
     // Order 에서 발행하는 이벤트 토픽
     @Value("${kafka-topics.order.created}") private String orderCreatedTopic;
@@ -64,6 +67,30 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic ticketCancelled() {
         return TopicBuilder.name(ticketCancelledTopic)
+                .partitions(defaultPartitions)
+                .replicas(defaultReplicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic ticketReservationRequest() {
+        return TopicBuilder.name(ticketReservationRequestTopic)
+                .partitions(10) // 티켓 예매 요청의 파티션은 10개로 설정
+                .replicas(defaultReplicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic ticketReservationSucceeded() {
+        return TopicBuilder.name(ticketReservationSucceededTopic)
+                .partitions(defaultPartitions)
+                .replicas(defaultReplicas)
+                .build();
+    }
+
+    @Bean
+    public NewTopic ticketReservationFailed() {
+        return TopicBuilder.name(ticketReservationFailedTopic)
                 .partitions(defaultPartitions)
                 .replicas(defaultReplicas)
                 .build();

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketDetailPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketDetailPayload.java
@@ -5,15 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TicketReservedPayload {
-    private List<TicketDetailPayload> ticketDetails;
-    private Long userId;
-    private UUID gameId;
+public class TicketDetailPayload {
+    private UUID ticketId;
+    private int price;
 }

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketInfoPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketInfoPayload.java
@@ -5,15 +5,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
 import java.util.UUID;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class TicketReservedPayload {
-    private List<TicketDetailPayload> ticketDetails;
-    private Long userId;
-    private UUID gameId;
+public class TicketInfoPayload {
+    private UUID seatId;
+    private int price;
 }

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationFailedPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationFailedPayload.java
@@ -1,0 +1,30 @@
+package com.fix.common_service.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketReservationFailedPayload {
+    private UUID reservationRequestId; // 추적용 ID
+    private Long userId;
+    private UUID gameId;
+    List<FailedSeatInfo> failedTicketDetails; // 예약에 실패한 좌석 정보
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FailedSeatInfo {
+        private UUID seatId;
+        private int price;
+        private String failureReason; // 실패 사유
+    }
+}

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationRequestPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationRequestPayload.java
@@ -1,0 +1,23 @@
+package com.fix.common_service.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketReservationRequestPayload {
+    private UUID reservationRequestId; // 추적용 ID
+    private Long userId;
+    private String queueToken; // 큐 토큰 (워커에서 최종 검증을 위해 필요)
+    private UUID gameId;
+    TicketInfoPayload ticketToProcess; // 예약할 티켓
+    List<TicketInfoPayload> originalTicketList; // 예약할 티켓의 원본 정보 (예약 요청 시점의 정보)
+    int totalTicketsInRequest; // 원본 요청의 총 티켓(좌석) 수 (결과 집계용)
+}

--- a/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationSucceededPayload.java
+++ b/common-service/src/main/java/com/fix/common_service/kafka/dto/TicketReservationSucceededPayload.java
@@ -1,0 +1,30 @@
+package com.fix.common_service.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketReservationSucceededPayload {
+    private UUID reservationRequestId; // 추적용 ID
+    private Long userId;
+    private UUID gameId;
+    List<ReservedTicketInfo> ticketDetails; // 예약에 성공한 티켓 정보
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReservedTicketInfo {
+        private UUID ticketId;
+        private UUID seatId;
+        private int price;
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/dtos/response/TicketReservationResponseDto.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/dtos/response/TicketReservationResponseDto.java
@@ -1,0 +1,16 @@
+package com.fix.ticket_service.application.dtos.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TicketReservationResponseDto {
+    private UUID reservationRequestId; // 예약 요청 ID
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/application/service/TicketApplicationService.java
@@ -530,20 +530,16 @@ public class TicketApplicationService {
     private <T> T mapObjectToDto(Object obj, Class<T> clazz) {
         if (obj == null) return null;
         try {
-            // If using GenericJackson2JsonRedisSerializer, it might already be a LinkedHashMap
             if (obj instanceof Map) {
                 com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-                // Configure mapper if needed (e.g., for UUIDs)
-                mapper.findAndRegisterModules(); // For JavaTime, etc.
+                mapper.findAndRegisterModules();
                 return mapper.convertValue(obj, clazz);
             } else if (clazz.isInstance(obj)) {
                 return clazz.cast(obj);
             } else {
-                log.warn("Cannot map object of type {} to {}", obj.getClass().getName(), clazz.getName());
                 return null;
             }
         } catch (Exception e) {
-            log.error("Error converting Redis object to DTO: {}", e.getMessage(), e);
             return null;
         }
     }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCanceledConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCanceledConsumer.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 public class OrderCanceledConsumer extends AbstractKafkaConsumer<OrderCancelledPayload> {
 
     private final TicketApplicationService ticketApplicationService;
+    private static final String CONSUMER_GROUP_ID = "ticket-service-order-canceled-consumer";
 
     public OrderCanceledConsumer(RedisIdempotencyChecker idempotencyChecker,
                                  TicketApplicationService ticketApplicationService) {
@@ -25,7 +26,7 @@ public class OrderCanceledConsumer extends AbstractKafkaConsumer<OrderCancelledP
         this.ticketApplicationService = ticketApplicationService;
     }
 
-    @KafkaListener(topics = "${kafka-topics.order.canceled}", groupId = "ticket-service-order-canceled-consumer")
+    @KafkaListener(topics = "${kafka-topics.order.canceled}", groupId = CONSUMER_GROUP_ID)
     public void listen(ConsumerRecord<String, EventKafkaMessage<OrderCancelledPayload>> record,
                        EventKafkaMessage<OrderCancelledPayload> message,
                        Acknowledgment ack) {
@@ -48,6 +49,6 @@ public class OrderCanceledConsumer extends AbstractKafkaConsumer<OrderCancelledP
 
     @Override
     protected String getConsumerGroupId() {
-        return "ticket-service-order-canceled-consumer";
+        return CONSUMER_GROUP_ID;
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletedConsumer.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class OrderCompletedConsumer extends AbstractKafkaConsumer<OrderCompletedPayload> {
 
     private final TicketApplicationService ticketApplicationService;
+    private static final String CONSUMER_GROUP_ID = "ticket-service-order-completed-consumer";
 
     public OrderCompletedConsumer(RedisIdempotencyChecker idempotencyChecker,
                                   TicketApplicationService ticketApplicationService) {
@@ -24,7 +25,7 @@ public class OrderCompletedConsumer extends AbstractKafkaConsumer<OrderCompleted
         this.ticketApplicationService = ticketApplicationService;
     }
 
-    @KafkaListener(topics = "${kafka-topics.order.completed}", groupId = "ticket-service-order-completed-consumer")
+    @KafkaListener(topics = "${kafka-topics.order.completed}", groupId = CONSUMER_GROUP_ID)
     public void listen(ConsumerRecord<String, EventKafkaMessage<OrderCompletedPayload>> record,
                        EventKafkaMessage<OrderCompletedPayload> message,
                        Acknowledgment ack) {
@@ -49,6 +50,6 @@ public class OrderCompletedConsumer extends AbstractKafkaConsumer<OrderCompleted
 
     @Override
     protected String getConsumerGroupId() {
-        return "ticket-service-order-completed-consumer";
+        return CONSUMER_GROUP_ID;
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletionFailedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCompletionFailedConsumer.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class OrderCompletionFailedConsumer extends AbstractKafkaConsumer<OrderCompletionFailedPayload> {
 
     private final TicketApplicationService ticketApplicationService;
+    private static final String CONSUMER_GROUP_ID = "ticket-service-order-completion-failed-consumer";
 
     public OrderCompletionFailedConsumer(RedisIdempotencyChecker idempotencyChecker,
                                          TicketApplicationService ticketApplicationService) {
@@ -23,7 +24,7 @@ public class OrderCompletionFailedConsumer extends AbstractKafkaConsumer<OrderCo
         this.ticketApplicationService = ticketApplicationService;
     }
 
-    @KafkaListener(topics = "${kafka-topics.order.completion-failed}", groupId = "ticket-service-order-completion-failed-consumer")
+    @KafkaListener(topics = "${kafka-topics.order.completion-failed}", groupId = CONSUMER_GROUP_ID)
     public void listen(ConsumerRecord<String, EventKafkaMessage<OrderCompletionFailedPayload>> record,
                        EventKafkaMessage<OrderCompletionFailedPayload> message,
                        Acknowledgment ack) {
@@ -46,6 +47,6 @@ public class OrderCompletionFailedConsumer extends AbstractKafkaConsumer<OrderCo
 
     @Override
     protected String getConsumerGroupId() {
-        return "ticket-service-order-completion-failed-consumer";
+        return CONSUMER_GROUP_ID;
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCreationFailedConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/OrderCreationFailedConsumer.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 public class OrderCreationFailedConsumer extends AbstractKafkaConsumer<OrderCreationFailedPayload> {
 
     private final TicketApplicationService ticketApplicationService;
+    private static final String CONSUMER_GROUP_ID = "ticket-service-order-creation-failed-consumer";
 
     public OrderCreationFailedConsumer(RedisIdempotencyChecker idempotencyChecker,
                                        TicketApplicationService ticketApplicationService) {
@@ -23,7 +24,7 @@ public class OrderCreationFailedConsumer extends AbstractKafkaConsumer<OrderCrea
         this.ticketApplicationService = ticketApplicationService;
     }
 
-    @KafkaListener(topics = "${kafka-topics.order.creation-failed}", groupId = "ticket-service-order-creation-failed-consumer")
+    @KafkaListener(topics = "${kafka-topics.order.creation-failed}", groupId = CONSUMER_GROUP_ID)
     public void listen(ConsumerRecord<String, EventKafkaMessage<OrderCreationFailedPayload>> record,
                        EventKafkaMessage<OrderCreationFailedPayload> message,
                        Acknowledgment ack) {
@@ -46,6 +47,6 @@ public class OrderCreationFailedConsumer extends AbstractKafkaConsumer<OrderCrea
 
     @Override
     protected String getConsumerGroupId() {
-        return "ticket-service-order-creation-failed-consumer";
+        return CONSUMER_GROUP_ID;
     }
 }

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketReservationRequestConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketReservationRequestConsumer.java
@@ -24,7 +24,7 @@ public class TicketReservationRequestConsumer extends AbstractKafkaConsumer<Tick
         this.ticketApplicationService = ticketApplicationService;
     }
 
-    @KafkaListener(topics = "${kafka-topics.ticket.reservation.request}", groupId = CONSUMER_GROUP_ID)
+    @KafkaListener(topics = "${kafka-topics.ticket.reservation.request}", groupId = CONSUMER_GROUP_ID, concurrency = "10")
     public void listen(ConsumerRecord<String, EventKafkaMessage<TicketReservationRequestPayload>> record,
                        EventKafkaMessage<TicketReservationRequestPayload> message,
                        Acknowledgment ack) {

--- a/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketReservationRequestConsumer.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/infrastructure/kafka/consumer/TicketReservationRequestConsumer.java
@@ -1,0 +1,51 @@
+package com.fix.ticket_service.infrastructure.kafka.consumer;
+
+import com.fix.common_service.kafka.consumer.AbstractKafkaConsumer;
+import com.fix.common_service.kafka.consumer.RedisIdempotencyChecker;
+import com.fix.common_service.kafka.dto.EventKafkaMessage;
+import com.fix.common_service.kafka.dto.TicketReservationRequestPayload;
+import com.fix.ticket_service.application.service.TicketApplicationService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TicketReservationRequestConsumer extends AbstractKafkaConsumer<TicketReservationRequestPayload> {
+
+    private final TicketApplicationService ticketApplicationService;
+    private static final String CONSUMER_GROUP_ID = "ticket-service-reservation-request-consumer";
+
+    public TicketReservationRequestConsumer(RedisIdempotencyChecker idempotencyChecker,
+                                            TicketApplicationService ticketApplicationService) {
+        super(idempotencyChecker);
+        this.ticketApplicationService = ticketApplicationService;
+    }
+
+    @KafkaListener(topics = "${kafka-topics.ticket.reservation.request}", groupId = CONSUMER_GROUP_ID)
+    public void listen(ConsumerRecord<String, EventKafkaMessage<TicketReservationRequestPayload>> record,
+                       EventKafkaMessage<TicketReservationRequestPayload> message,
+                       Acknowledgment ack) {
+        super.consume(record, message, ack);
+    }
+
+    @Override
+    protected void processPayload(Object payload) {
+        TicketReservationRequestPayload reservationRequestPayload = mapPayload(payload, TicketReservationRequestPayload.class);
+        try {
+            ticketApplicationService.processReservation(reservationRequestPayload);
+            log.info("[Kafka] 티켓 예약 요청 처리 성공: reservationRequestId={}", reservationRequestPayload.getReservationRequestId());
+        } catch (Exception e) {
+            // 에러 핸들러에 의한 재시도 처리
+            log.error("[Kafka] 티켓 예약 요청 처리 실패: reservationRequestId={}, error={}", reservationRequestPayload.getReservationRequestId(), e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
+    protected String getConsumerGroupId() {
+        return CONSUMER_GROUP_ID;
+    }
+}

--- a/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
+++ b/ticket-service/src/main/java/com/fix/ticket_service/presentation/controller/TicketController.java
@@ -32,6 +32,17 @@ public class TicketController {
         return ResponseEntity.ok(CommonResponse.success(responseDto, "티켓 예약 성공"));
     }
 
+    // ✅ 티켓 예약 요청 API (신규 Kafka 비동기 방식)
+    @ApiLogging
+    @PostMapping("/reserve-async")
+    public ResponseEntity<CommonResponse<TicketReservationResponseDto>> reserveTicketAsync(
+        @RequestBody TicketReserveRequestDto request,
+        @RequestHeader("x-user-id") Long userId,
+        @RequestHeader("QueueToken") String queueToken) {
+        TicketReservationResponseDto responseDto = ticketApplicationService.initiateAsyncReservation(request, userId, queueToken);
+        return ResponseEntity.status(202).body(CommonResponse.success(responseDto, "티켓 예약 요청 성공"));
+    }
+
     // ✅ 티켓 단건 상세 조회 API
     @GetMapping("/{ticketId}")
     public ResponseEntity<CommonResponse<TicketDetailResponseDto>> getTicket(


### PR DESCRIPTION
## 🚀 PR 제목 (무엇을 했는가?)
Kafka 기반 비동기 병렬 처리를 통한 티켓 예매 처리량 개선
---

## 📌 작업 개요
- 사용자의 예매 요청 접수(API 요청)과 실제 예매 처리 로직(별도 Worker)을 분리하여 시스템 부하 분산 및 처리량 개선

---

## ✅ 변경 사항 체크리스트
- [ ] 테스트 코드 포함 여부
- [ ] API 명세 문서 작성 (Swagger 등)
- [ ] 예외 처리 및 유효성 검사 적용
- [ ] 기존 기능에 영향 없음 확인
- [ ] CI/CD 파이프라인 통과

---

## 🔍 코멘트
- 예매 요청과 실제 예매 처리를 분리하여 요청 처리를 비동기 병렬 처리로 구현해 처리량을 높였습니다.
- 자세한 내용은 (https://www.notion.so/teamsparta/1c92dc3ef51481aa96e0da1ee146b453?p=1e42dc3ef514809dbfc4c3b4aa224dbc&pm=s) 여기에 정리해두었습니다.
- 기존 동기 처리 방식의 API도 일단 제거하지 않고 그대로 뒀습니다. (비교 테스트 용)
- 한 번의 요청에서 여러 개의 좌석을 예매할 수 있다는 정책으로 인해 구현 복잡도가 많이 늘어나서.. 시간이 좀 오래걸렸습니다. 


---

## 🧪 테스트 방법 (선택)
- [ ] Postman 테스트
- [ ] Swagger 테스트
- [ ] 통합 테스트 클래스

테스트 URI 및 요청/응답 예시 (선택):